### PR TITLE
Use React 18 createRoot

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import ReactDOM from "react-dom";
+import { createRoot } from "react-dom/client";
 import "./index.css";
 import App from "./App";
 import reportWebVitals from "./reportWebVitals";
@@ -9,11 +9,11 @@ const targetElement = document.getElementById(
 );
 
 if (targetElement) {
-  ReactDOM.render(
+  const root = createRoot(targetElement);
+  root.render(
     <React.StrictMode>
       <App />
-    </React.StrictMode>,
-    targetElement
+    </React.StrictMode>
   );
 }
 


### PR DESCRIPTION
Hi team!

We already created this project with React 18, but only partially [because of it](https://reactjs.org/blog/2022/03/29/react-v18.html#react-dom-client):

> `createRoot`: New method to create a root to `render` or `unmount`. Use it instead of `ReactDOM.render`. **New features in React 18 don’t work without it**.

We are not taking advantage of the new features, but I think that it is better to be ready now to avoid difficult migrations in the future.