### PR TITLE
Fix: onSessionUpdate method call

### DIFF
--- a/src/session/AppSessionStateContext.tsx
+++ b/src/session/AppSessionStateContext.tsx
@@ -35,6 +35,7 @@ export function AppSessionStateProvider({
         isTheSameSession(previousState, newState) ? previousState : newState
       );
     };
+    appSessionStateClient.onSessionUpdate();
     return () => {
       appSessionStateClient.onSessionUpdate = () => {};
     };


### PR DESCRIPTION
Related JIRA: [https://makingsense.atlassian.net/browse/DE-693](https://makingsense.atlassian.net/browse/DE-693)

Issue (intermittently): on user session update event is launched before onSessionUpdate is defined.

Fix: we add a call to onSessionUpdate right after is defined.