### PR TITLE
Patch WebApp URLs in local

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -55,6 +55,28 @@
       <div>
         <header id="root-header"></header>
         <div id="root"></div>
+
+        <div class="dp-container">
+          <br />
+          <h2>Buttons to simulate SPA navigation</h2>
+          <button
+            type="button"
+            class="dp-button button-medium primary-green button--round m-r-24"
+            onclick="window.history.pushState({}, '', '/dashboard')"
+          >
+            Dashboard
+          </button>
+          <button
+            type="button"
+            class="dp-button button-medium primary-green button--round"
+            onclick="window.history.pushState({}, '', '/reports')"
+          >
+            Reports
+          </button>
+          <br />
+          <br />
+        </div>
+
         <footer id="root-footer"></footer>
       </div>
     </div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,23 +19,18 @@ function App() {
     appSessionState.userData;
 
   // For testing in testmenu enviroment
-  const patchWebAppUrl = (url: string): string => {
-    const isWebAppUrl = webappDomainRegex.test(url);
-    return isWebAppUrl ? url.replace(webappDomainRegex, origin) : url;
-  };
-
   const shouldPatchWebAppUrls = applyUrlPatchInTheseDomainsRegex.test(origin);
 
   const navigation = shouldPatchWebAppUrls
     ? nav.map((navElement) => {
         return {
           ...navElement,
-          url: patchWebAppUrl(navElement.url),
+          url: navElement.url?.replace(webappDomainRegex, origin),
           ...(navElement.subNav && {
             subNav: navElement.subNav.map((subNavElement) => {
               return {
                 ...subNavElement,
-                url: patchWebAppUrl(subNavElement.url),
+                url: subNavElement.url?.replace(webappDomainRegex, origin),
               };
             }),
           }),

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,7 +5,7 @@ import { useAppSessionState } from "./session/AppSessionStateContext";
 const webappDomainRegex =
   /^https?:\/\/(?:webapp(?:qa|int)\.fromdoppler\.net|app\.fromdoppler\.com)(?=\/|$)/;
 const applyUrlPatchInTheseDomainsRegex =
-  /^https?:\/\/(?:testmenu(?:qa|int)\.fromdoppler\.net|testmenu\.fromdoppler\.com)(?=\/|$)/;
+  /^https?:\/\/(?:testmenu(?:qa|int)\.fromdoppler\.net|testmenu\.fromdoppler\.com|localhost:3000)(?=\/|$)/;
 
 function App() {
   const { href, origin } = window.location;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,7 +6,7 @@ const testmenu = "testmenu";
 const webAppSubDomainRegex =
   /(?<=http[s]*:\/\/)webapp(?=qa|int)|app(?=\.)(?=[^/]*\.)/gi;
 
-const testMenuSubDomainRegex =
+const applyUrlPatchInTheseDomainsRegex =
   /(?<=http[s]*:\/\/)((testmenu(qa|int)*))(?=\.)(?=[^/]*\.)/gi;
 
 function App() {
@@ -21,23 +21,23 @@ function App() {
     appSessionState.userData;
 
   // For testing in testmenu enviroment
-  const replaceUrl = (url: string): string => {
+  const patchWebAppUrl = (url: string): string => {
     const isWebAppUrl = webAppSubDomainRegex.test(url);
     return isWebAppUrl ? url.replace(webAppSubDomainRegex, testmenu) : url;
   };
 
-  const isTestMenuEnv = testMenuSubDomainRegex.test(origin);
+  const shouldPatchWebAppUrls = applyUrlPatchInTheseDomainsRegex.test(origin);
 
-  const navigation = isTestMenuEnv
+  const navigation = shouldPatchWebAppUrls
     ? nav.map((navElement) => {
         return {
           ...navElement,
-          url: replaceUrl(navElement.url),
+          url: patchWebAppUrl(navElement.url),
           ...(navElement.subNav && {
             subNav: navElement.subNav.map((subNavElement) => {
               return {
                 ...subNavElement,
-                url: replaceUrl(subNavElement.url),
+                url: patchWebAppUrl(subNavElement.url),
               };
             }),
           }),

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,12 +2,10 @@ import { Header, HeaderPlaceholder } from "./components/Header";
 import { HeaderMessages } from "./components/HeaderMessages";
 import { useAppSessionState } from "./session/AppSessionStateContext";
 
-const testmenu = "testmenu";
-const webAppSubDomainRegex =
-  /(?<=http[s]*:\/\/)webapp(?=qa|int)|app(?=\.)(?=[^/]*\.)/gi;
-
+const webappDomainRegex =
+  /^https?:\/\/(?:webapp(?:qa|int)\.fromdoppler\.net|app\.fromdoppler\.com)(?=\/|$)/;
 const applyUrlPatchInTheseDomainsRegex =
-  /(?<=http[s]*:\/\/)((testmenu(qa|int)*))(?=\.)(?=[^/]*\.)/gi;
+  /^https?:\/\/(?:testmenu(?:qa|int)\.fromdoppler\.net|testmenu\.fromdoppler\.com)(?=\/|$)/;
 
 function App() {
   const { href, origin } = window.location;
@@ -22,8 +20,8 @@ function App() {
 
   // For testing in testmenu enviroment
   const patchWebAppUrl = (url: string): string => {
-    const isWebAppUrl = webAppSubDomainRegex.test(url);
-    return isWebAppUrl ? url.replace(webAppSubDomainRegex, testmenu) : url;
+    const isWebAppUrl = webappDomainRegex.test(url);
+    return isWebAppUrl ? url.replace(webappDomainRegex, origin) : url;
   };
 
   const shouldPatchWebAppUrls = applyUrlPatchInTheseDomainsRegex.test(origin);


### PR DESCRIPTION
Hi team!

It is to run the patch URLs code in the local environment. I have also refactored the code to make it more friendly (friendly with me 😛)

I also added simple code to allow us to simulate SPA navigation in the local environment:

![2022-08-03_09-06-12 (1)](https://user-images.githubusercontent.com/1157864/182605602-d966340a-f454-4196-9915-b74c5e890671.gif)

As you can see, the menu only reacts to URL changes after a reload, it should be fixed in #121

Thoughts?

---

**Update:** I applied some fixes in the button styles

![image](https://user-images.githubusercontent.com/1157864/182845330-e03ba3f0-5e98-4f92-8d73-ea3f97179918.png)
