### PR TITLE
Wait for DOMContentLoadedif the target element is not available yet

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -15,6 +15,28 @@ const configuration: AppConfiguration = readConfiguration(window);
 const targetElement = getTargetElement(document, configuration);
 
 if (targetElement) {
+  initialize(window, configuration, targetElement);
+} else {
+  // In some scenarios, the target element is not available yet, so we need to wait for it.
+  // For example, now it is happening in resports2
+  document.addEventListener("DOMContentLoaded", () => {
+    const targetElement = getTargetElement(document, configuration);
+    if (targetElement) {
+      initialize(window, configuration, targetElement);
+    }
+  });
+}
+
+// If you want to start measuring performance in your app, pass a function
+// to log results (for example: reportWebVitals(console.log))
+// or send to an analytics endpoint. Learn more: https://bit.ly/CRA-vitals
+reportWebVitals();
+
+function initialize(
+  window: Window,
+  configuration: AppConfiguration,
+  targetElement: HTMLElement
+) {
   const appSessionStateClient = createAppSessionStateClient(
     window,
     configuration
@@ -32,11 +54,6 @@ if (targetElement) {
     </StrictMode>
   );
 }
-
-// If you want to start measuring performance in your app, pass a function
-// to log results (for example: reportWebVitals(console.log))
-// or send to an analytics endpoint. Learn more: https://bit.ly/CRA-vitals
-reportWebVitals();
 
 function readConfiguration(window: Window): AppConfiguration {
   return (window as any)["doppler-menu-mfe-configuration"] ?? {};


### PR DESCRIPTION
In Reports, the HTML rendering is slower than Menu MFE loading, so, it was failing randomly in this way:

Before the fix:

![image](https://user-images.githubusercontent.com/1157864/185470123-7782ca73-2f67-4072-bb2e-8b755b0d8325.png)

After the fix:

![image](https://user-images.githubusercontent.com/1157864/185470656-54252d3c-0e36-495f-b111-e95d57d7be1d.png)
