### PR TITLE
[DE-729] Refactorización de formulario de suscriptores

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ Thumbs.db
 
 #InteliJ
 .idea
+.run

--- a/src/client/DopplerLegacyClientImpl.ts
+++ b/src/client/DopplerLegacyClientImpl.ts
@@ -3,7 +3,7 @@ import { DopplerLegacyClient } from "./dopplerLegacyClient";
 import {
   AnswerType,
   MaxSubscribersData,
-  MaxSubscribersQuestion,
+  QuestionModel,
 } from "../components/ValidateSubscriber/types";
 
 const mapMaxSubscribersData = (json: any): MaxSubscribersData => {
@@ -17,7 +17,7 @@ const mapMaxSubscribersData = (json: any): MaxSubscribersData => {
   };
 };
 
-const mapMaxSubscribersQuestion = (json: any): MaxSubscribersQuestion => {
+const mapMaxSubscribersQuestion = (json: any): QuestionModel => {
   return {
     question: json.Question,
     answer: {
@@ -29,9 +29,7 @@ const mapMaxSubscribersQuestion = (json: any): MaxSubscribersQuestion => {
   };
 };
 
-const mapMaxSubscribersQuestionData = (
-  question: MaxSubscribersQuestion
-): any => {
+const mapMaxSubscribersQuestionData = (question: QuestionModel): any => {
   return {
     Question: question.question,
     Answer: {

--- a/src/components/HeaderMessages.tsx
+++ b/src/components/HeaderMessages.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { ReactNode, useState } from "react";
 import { Modal } from "./Modal";
 import { User, Alert } from "../model";
 import { UpgradePlanForm } from "./UpgradePlanForm";
@@ -13,34 +13,17 @@ const upgradePlanPopup = "upgradePlanPopup";
 const validateSubscribersPopup = "validateSubscribersPopup";
 
 export const HeaderMessages = ({ alert, user }: HeaderMessagesProp) => {
+  const [modalIsOpen, setModalIsOpen] = useState(false);
+
+  if (!Object.keys(alert).length) {
+    return null;
+  }
+
   const { plan } = user;
   const { type, message, button } = alert;
 
-  const [modalIsOpen, setModalIsOpen] = useState(false);
   const toggleModal = (isOpen: boolean) => setModalIsOpen(isOpen);
   // TODO: nextAlert logic
-
-  const showLink = ({ text, url }: { text: string; url: string }) => (
-    <a
-      href={url}
-      className="button button--light button--tiny"
-      data-testid="linkButton"
-    >
-      {text}
-    </a>
-  );
-
-  const showButton = ({ text }: { text: string; action: string }) => (
-    <button
-      className="button button--light button--tiny"
-      data-testid="actionButton"
-      onClick={() => toggleModal(true)}
-    >
-      {text}
-    </button>
-  );
-
-  if (!Object.keys(alert).length) return null;
 
   // Only validateSubscribersPopup and upgradePlanPopup actions are supported
   const hasModal =
@@ -48,16 +31,22 @@ export const HeaderMessages = ({ alert, user }: HeaderMessagesProp) => {
     (button.action === validateSubscribersPopup ||
       button?.action === upgradePlanPopup);
 
+  const showAction = button?.url || button?.action;
+
   return (
     <>
       <div className={`messages-container sticky ${type}`}>
         <div className="wrapper">
           {message && <p>{message}</p>}
-          {button?.url
-            ? showLink(button)
-            : button?.action
-            ? showButton(button)
-            : null}
+          {showAction && (
+            <ActionComponent
+              type={button?.url ? "LINK" : "BUTTON"}
+              url={button?.url}
+              onClick={() => toggleModal(true)}
+            >
+              {button?.text}
+            </ActionComponent>
+          )}
         </div>
       </div>
       {hasModal && (
@@ -80,5 +69,33 @@ export const HeaderMessages = ({ alert, user }: HeaderMessagesProp) => {
         </Modal>
       )}
     </>
+  );
+};
+
+interface ActionComponentProps {
+  url?: string;
+  onClick?: () => void;
+  children: string | ReactNode;
+  type: "BUTTON" | "LINK";
+}
+
+const ActionComponent = ({
+  children,
+  type,
+  url,
+  onClick,
+}: ActionComponentProps) => {
+  if (type === "LINK") {
+    return (
+      <a href={url} className="button button--light button--tiny">
+        {children}
+      </a>
+    );
+  }
+
+  return (
+    <button className="button button--light button--tiny" onClick={onClick}>
+      {children}
+    </button>
   );
 };

--- a/src/components/HeaderMessages.tsx
+++ b/src/components/HeaderMessages.tsx
@@ -69,10 +69,7 @@ export const HeaderMessages = ({ alert, user }: HeaderMessagesProp) => {
           }
         >
           {button?.action === validateSubscribersPopup ? (
-            <ValidateSubscribers
-              handleClose={() => toggleModal(false)}
-              setNextAlert={() => {}}
-            />
+            <ValidateSubscribers handleClose={() => toggleModal(false)} />
           ) : (
             <UpgradePlanForm
               isSubscriber={plan.isSubscribers}

--- a/src/components/HeaderMessages.tsx
+++ b/src/components/HeaderMessages.tsx
@@ -2,7 +2,7 @@ import { ReactNode, useState } from "react";
 import { Modal } from "./Modal";
 import { User, Alert } from "../model";
 import { UpgradePlanForm } from "./UpgradePlanForm";
-import { ValidateSubscribers } from "./ValidateSubscriber/ValidateSubscribers";
+import { ValidateSubscribersForm } from "./ValidateSubscriber/ValidateSubscribersForm";
 
 interface HeaderMessagesProp {
   alert: Alert;
@@ -58,7 +58,7 @@ export const HeaderMessages = ({ alert, user }: HeaderMessagesProp) => {
           }
         >
           {button?.action === validateSubscribersPopup ? (
-            <ValidateSubscribers handleClose={() => toggleModal(false)} />
+            <ValidateSubscribersForm handleClose={() => toggleModal(false)} />
           ) : (
             <UpgradePlanForm
               isSubscriber={plan.isSubscribers}

--- a/src/components/ValidateSubscriber/CheckBoxQuestion.tsx
+++ b/src/components/ValidateSubscriber/CheckBoxQuestion.tsx
@@ -26,7 +26,7 @@ export const CheckBoxQuestion = ({
               : undefined
           }
         />
-        {isCheckOtherOption && isLastOption ? (
+        {enableOtherOption && isLastOption ? (
           <div
             className={`${isCheckOtherOption ? "dp-show" : "dp-hide"}`}
             data-testid="last-textarea"

--- a/src/components/ValidateSubscriber/CheckBoxQuestion.tsx
+++ b/src/components/ValidateSubscriber/CheckBoxQuestion.tsx
@@ -1,0 +1,102 @@
+import { CheckboxFieldItem, FieldGroup } from "./form-helpers";
+import React, { useState } from "react";
+import { Field } from "formik";
+import { FormattedMessage } from "react-intl";
+
+export const CheckBoxQuestion = ({
+  fieldName,
+  question,
+  options,
+  enableOtherOption,
+  error,
+}: CheckBoxQuestionProps) => {
+  const [isCheckOtherOption, setCheckOthersOption] = useState(false);
+
+  const optionsToRender = options.map((option, index) => {
+    const isLastOption = options.length - 1 === index;
+    return (
+      <React.Fragment key={`checkbox${index}`}>
+        <CheckBoxOption
+          option={option}
+          fieldName={fieldName}
+          index={`${fieldName}-${index}`}
+          onClick={
+            enableOtherOption
+              ? () => isLastOption && setCheckOthersOption(!isCheckOtherOption)
+              : undefined
+          }
+        />
+        {isCheckOtherOption && isLastOption ? (
+          <div
+            className={`${isCheckOtherOption ? "dp-show" : "dp-hide"}`}
+            data-testid="last-textarea"
+          >
+            <Field
+              as="textarea"
+              name={`answer${index}_text`}
+              className={"field-item"}
+            />
+          </div>
+        ) : (
+          ""
+        )}
+      </React.Fragment>
+    );
+  });
+
+  return (
+    <li className="m-t-6">
+      <fieldset>
+        <label htmlFor={question}> {question} </label>
+        <FieldGroup>
+          {optionsToRender}
+          {error ? (
+            <li className="field-item error">
+              <div className="dp-message dp-error-form">
+                <p>
+                  <FormattedMessage id={error} />
+                </p>
+              </div>
+            </li>
+          ) : (
+            ""
+          )}
+        </FieldGroup>
+      </fieldset>
+    </li>
+  );
+};
+
+const CheckBoxOption = ({
+  option,
+  fieldName,
+  index,
+  onClick,
+}: CheckBoxOptionProp) => {
+  return (
+    <CheckboxFieldItem
+      className={"field-item--50"}
+      label={option}
+      fieldName={fieldName}
+      id={index}
+      value={option}
+      onClick={() => onClick && onClick()}
+      withErrors={false}
+    />
+  );
+};
+
+interface CheckBoxQuestionProps {
+  question: string;
+  fieldName: string;
+  options: string[];
+  enableOtherOption?: boolean;
+  error?: string;
+}
+
+interface CheckBoxOptionProp {
+  option: string;
+  fieldName: string;
+  index: string;
+  onClick?: () => void;
+}

--- a/src/components/ValidateSubscriber/InputQuestion.tsx
+++ b/src/components/ValidateSubscriber/InputQuestion.tsx
@@ -1,9 +1,9 @@
-import { MaxSubscribersQuestion } from "./types";
+import { QuestionModel } from "./types";
 import { InputFieldItem } from "./form-helpers";
 import React from "react";
 
 interface InputQuestionProp {
-  questionItem: MaxSubscribersQuestion;
+  questionItem: QuestionModel;
   fieldName: string;
   className: string;
 }

--- a/src/components/ValidateSubscriber/InputQuestion.tsx
+++ b/src/components/ValidateSubscriber/InputQuestion.tsx
@@ -1,0 +1,25 @@
+import { MaxSubscribersQuestion } from "./types";
+import { InputFieldItem } from "./form-helpers";
+import React from "react";
+
+interface InputQuestionProp {
+  questionItem: MaxSubscribersQuestion;
+  fieldName: string;
+  className: string;
+}
+
+export const InputQuestion = ({
+  questionItem,
+  fieldName,
+  ...otherProps
+}: InputQuestionProp) => {
+  return (
+    <InputFieldItem
+      type="text"
+      label={questionItem.question}
+      fieldName={fieldName}
+      required
+      {...otherProps}
+    />
+  );
+};

--- a/src/components/ValidateSubscriber/Question.tsx
+++ b/src/components/ValidateSubscriber/Question.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { MaxSubscribersQuestion } from "./types";
+import { QuestionModel } from "./types";
 import { InputQuestion } from "./InputQuestion";
 import { CheckBoxQuestion } from "./CheckBoxQuestion";
 
@@ -40,7 +40,7 @@ export const Question = ({ questionItem, fieldName, error }: QuestionProp) => {
 };
 
 interface QuestionProp {
-  questionItem: MaxSubscribersQuestion;
+  questionItem: QuestionModel;
   fieldName: string;
   error?: string;
 }

--- a/src/components/ValidateSubscriber/Question.tsx
+++ b/src/components/ValidateSubscriber/Question.tsx
@@ -1,0 +1,46 @@
+import React from "react";
+import { MaxSubscribersQuestion } from "./types";
+import { InputQuestion } from "./InputQuestion";
+import { CheckBoxQuestion } from "./CheckBoxQuestion";
+
+export const Question = ({ questionItem, fieldName, error }: QuestionProp) => {
+  const answerType = questionItem.answer?.answerType;
+  switch (answerType) {
+    case "CHECKBOX":
+      return (
+        <CheckBoxQuestion
+          question={questionItem.question}
+          fieldName={fieldName}
+          options={questionItem.answer.answerOptions}
+          error={error}
+        />
+      );
+    case "CHECKBOX_WITH_TEXTAREA":
+      return (
+        <CheckBoxQuestion
+          question={questionItem.question}
+          fieldName={fieldName}
+          options={questionItem.answer.answerOptions}
+          enableOtherOption={true}
+          error={error}
+        />
+      );
+    default:
+      const inputClassName = `${
+        answerType === "TEXTFIELD" ? "field-item--50" : ""
+      }`;
+      return (
+        <InputQuestion
+          questionItem={questionItem}
+          fieldName={fieldName}
+          className={inputClassName}
+        />
+      );
+  }
+};
+
+interface QuestionProp {
+  questionItem: MaxSubscribersQuestion;
+  fieldName: string;
+  error?: string;
+}

--- a/src/components/ValidateSubscriber/QuestionsForm.test.tsx
+++ b/src/components/ValidateSubscriber/QuestionsForm.test.tsx
@@ -2,7 +2,7 @@ import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import "@testing-library/jest-dom/extend-expect";
 import { IntlProviderDouble } from "../i18n/DopplerIntlProvider.double-with-ids-as-values";
-import { ValidateMaxSubscribersForm } from "./ValidateMaxSubscribersForm";
+import { QuestionsForm } from "./QuestionsForm";
 import { QuestionModel } from "./types";
 import { AppConfigurationProvider } from "../../AppConfiguration";
 
@@ -54,7 +54,7 @@ const questionsMock: QuestionModel[] = [
   },
 ];
 
-describe("ValidateSubscribersFormComponent", () => {
+describe(QuestionsForm.name, () => {
   it("should not call handleSubmit when fields are empty", async () => {
     // Arrange
     const handleSubmit = jest.fn();
@@ -62,10 +62,7 @@ describe("ValidateSubscribersFormComponent", () => {
     // Act
     render(
       <IntlProviderDouble>
-        <ValidateMaxSubscribersForm
-          questions={questionsMock}
-          onSubmit={handleSubmit}
-        />
+        <QuestionsForm questions={questionsMock} onSubmit={handleSubmit} />
       </IntlProviderDouble>
     );
 
@@ -80,7 +77,7 @@ describe("ValidateSubscribersFormComponent", () => {
   it("should call handleSubmit when all fields are valid", async () => {
     // Arrange
     const name = "John Doe";
-    const url = "http://www.someurl.com";
+    const url = "https://www.someurl.com";
     const sourceSelected = "Online/Offline Store";
     const subscriptionMethod = "Opt-in";
     const handleSubmit = jest.fn();
@@ -89,10 +86,7 @@ describe("ValidateSubscribersFormComponent", () => {
     render(
       <AppConfigurationProvider configuration={{ useDummies: true }}>
         <IntlProviderDouble>
-          <ValidateMaxSubscribersForm
-            questions={questionsMock}
-            onSubmit={handleSubmit}
-          />
+          <QuestionsForm questions={questionsMock} onSubmit={handleSubmit} />
         </IntlProviderDouble>
       </AppConfigurationProvider>
     );
@@ -133,10 +127,7 @@ describe("ValidateSubscribersFormComponent", () => {
     // Act
     render(
       <IntlProviderDouble>
-        <ValidateMaxSubscribersForm
-          questions={questionsMock}
-          onSubmit={jest.fn()}
-        />
+        <QuestionsForm questions={questionsMock} onSubmit={jest.fn()} />
       </IntlProviderDouble>
     );
 
@@ -152,10 +143,7 @@ describe("ValidateSubscribersFormComponent", () => {
     // Act
     render(
       <IntlProviderDouble>
-        <ValidateMaxSubscribersForm
-          questions={questionsMock}
-          onSubmit={jest.fn()}
-        />
+        <QuestionsForm questions={questionsMock} onSubmit={jest.fn()} />
       </IntlProviderDouble>
     );
 

--- a/src/components/ValidateSubscriber/QuestionsForm.tsx
+++ b/src/components/ValidateSubscriber/QuestionsForm.tsx
@@ -6,19 +6,19 @@ import { QuestionModel, AnswerModel } from "./types";
 import { Question } from "./Question";
 import { Loading } from "../Loading";
 
-export interface ValidateMaxSubscribersFormProp {
+export interface QuestionsFormProps {
   questions: QuestionModel[];
   onSubmit: () => Promise<boolean>;
   customSubmit?: ReactNode;
   className?: string;
 }
 
-export const ValidateMaxSubscribersForm = ({
+export const QuestionsForm = ({
   questions,
   onSubmit,
   customSubmit,
   ...otherProps
-}: ValidateMaxSubscribersFormProp) => {
+}: QuestionsFormProps) => {
   const isCheckbox = (answer: AnswerModel) => {
     return ["CHECKBOX_WITH_TEXTAREA", "CHECKBOX"].includes(answer.answerType);
   };

--- a/src/components/ValidateSubscriber/ValidateMaxSubscribersForm.test.tsx
+++ b/src/components/ValidateSubscriber/ValidateMaxSubscribersForm.test.tsx
@@ -3,63 +3,56 @@ import userEvent from "@testing-library/user-event";
 import "@testing-library/jest-dom/extend-expect";
 import { IntlProviderDouble } from "../i18n/DopplerIntlProvider.double-with-ids-as-values";
 import { ValidateMaxSubscribersForm } from "./ValidateMaxSubscribersForm";
-import { MaxSubscribersData } from "./types";
+import { QuestionModel } from "./types";
 import { AppConfigurationProvider } from "../../AppConfiguration";
 
-const mockFormData: MaxSubscribersData = {
-  isSentSuccessEmail: false,
-  urlReferrer: "",
-  urlHelp:
-    "http://help.fromdoppler.com/por-que-debo-completar-un-formulario-al-cargar-mis-listas/",
-  questionsList: [
-    {
-      answer: {
-        answerType: "TEXTFIELD",
-        answerOptions: [],
-        value: "",
-        optionsSelected: [],
-      },
-      question: "Name",
+const questionsMock: QuestionModel[] = [
+  {
+    answer: {
+      answerType: "TEXTFIELD",
+      answerOptions: [],
+      value: "",
+      optionsSelected: [],
     },
-    {
-      answer: {
-        answerType: "URL",
-        answerOptions: [],
-        value: "",
-        optionsSelected: [],
-      },
-      question: "URL",
+    question: "Name",
+  },
+  {
+    answer: {
+      answerType: "URL",
+      answerOptions: [],
+      value: "",
+      optionsSelected: [],
     },
-    {
-      answer: {
-        answerType: "CHECKBOX_WITH_TEXTAREA",
-        answerOptions: [
-          "Website",
-          "Event",
-          "Landing Page",
-          "CRM",
-          "Personal Agenda",
-          "Online/Offline Store",
-          "Others",
-        ],
-        value: "",
-        optionsSelected: [],
-      },
-      question:
-        "Which of the following can be considered as your Subscribers’ source?",
+    question: "URL",
+  },
+  {
+    answer: {
+      answerType: "CHECKBOX_WITH_TEXTAREA",
+      answerOptions: [
+        "Website",
+        "Event",
+        "Landing Page",
+        "CRM",
+        "Personal Agenda",
+        "Online/Offline Store",
+        "Others",
+      ],
+      value: "",
+      optionsSelected: [],
     },
-    {
-      answer: {
-        answerType: "CHECKBOX",
-        answerOptions: ["Opt-in", "Doble Opt-in", "Manual"],
-        value: "",
-        optionsSelected: [],
-      },
-      question:
-        "Which was the subscription method used to create your database?",
+    question:
+      "Which of the following can be considered as your Subscribers’ source?",
+  },
+  {
+    answer: {
+      answerType: "CHECKBOX",
+      answerOptions: ["Opt-in", "Doble Opt-in", "Manual"],
+      value: "",
+      optionsSelected: [],
     },
-  ],
-};
+    question: "Which was the subscription method used to create your database?",
+  },
+];
 
 describe("ValidateSubscribersFormComponent", () => {
   it("should not call handleSubmit when fields are empty", async () => {
@@ -70,7 +63,7 @@ describe("ValidateSubscribersFormComponent", () => {
     render(
       <IntlProviderDouble>
         <ValidateMaxSubscribersForm
-          validationFormData={mockFormData}
+          questions={questionsMock}
           onSubmit={handleSubmit}
         />
       </IntlProviderDouble>
@@ -97,7 +90,7 @@ describe("ValidateSubscribersFormComponent", () => {
       <AppConfigurationProvider configuration={{ useDummies: true }}>
         <IntlProviderDouble>
           <ValidateMaxSubscribersForm
-            validationFormData={mockFormData}
+            questions={questionsMock}
             onSubmit={handleSubmit}
           />
         </IntlProviderDouble>
@@ -141,7 +134,7 @@ describe("ValidateSubscribersFormComponent", () => {
     render(
       <IntlProviderDouble>
         <ValidateMaxSubscribersForm
-          validationFormData={mockFormData}
+          questions={questionsMock}
           onSubmit={jest.fn()}
         />
       </IntlProviderDouble>
@@ -160,7 +153,7 @@ describe("ValidateSubscribersFormComponent", () => {
     render(
       <IntlProviderDouble>
         <ValidateMaxSubscribersForm
-          validationFormData={mockFormData}
+          questions={questionsMock}
           onSubmit={jest.fn()}
         />
       </IntlProviderDouble>

--- a/src/components/ValidateSubscriber/ValidateMaxSubscribersForm.test.tsx
+++ b/src/components/ValidateSubscriber/ValidateMaxSubscribersForm.test.tsx
@@ -71,8 +71,8 @@ describe("ValidateSubscribersFormComponent", () => {
       <IntlProviderDouble>
         <ValidateMaxSubscribersForm
           validationFormData={mockFormData}
-          handleSubmit={handleSubmit}
-          handleClose={jest.fn()}
+          onSubmit={handleSubmit}
+          onClose={jest.fn()}
         />
       </IntlProviderDouble>
     );
@@ -99,8 +99,8 @@ describe("ValidateSubscribersFormComponent", () => {
         <IntlProviderDouble>
           <ValidateMaxSubscribersForm
             validationFormData={mockFormData}
-            handleSubmit={handleSubmit}
-            handleClose={jest.fn()}
+            onSubmit={handleSubmit}
+            onClose={jest.fn()}
           />
         </IntlProviderDouble>
       </AppConfigurationProvider>
@@ -144,8 +144,8 @@ describe("ValidateSubscribersFormComponent", () => {
       <IntlProviderDouble>
         <ValidateMaxSubscribersForm
           validationFormData={mockFormData}
-          handleClose={jest.fn()}
-          handleSubmit={jest.fn()}
+          onClose={jest.fn()}
+          onSubmit={jest.fn()}
         />
       </IntlProviderDouble>
     );
@@ -164,8 +164,8 @@ describe("ValidateSubscribersFormComponent", () => {
       <IntlProviderDouble>
         <ValidateMaxSubscribersForm
           validationFormData={mockFormData}
-          handleClose={jest.fn()}
-          handleSubmit={jest.fn()}
+          onClose={jest.fn()}
+          onSubmit={jest.fn()}
         />
       </IntlProviderDouble>
     );

--- a/src/components/ValidateSubscriber/ValidateMaxSubscribersForm.test.tsx
+++ b/src/components/ValidateSubscriber/ValidateMaxSubscribersForm.test.tsx
@@ -72,7 +72,6 @@ describe("ValidateSubscribersFormComponent", () => {
         <ValidateMaxSubscribersForm
           validationFormData={mockFormData}
           onSubmit={handleSubmit}
-          onClose={jest.fn()}
         />
       </IntlProviderDouble>
     );
@@ -100,7 +99,6 @@ describe("ValidateSubscribersFormComponent", () => {
           <ValidateMaxSubscribersForm
             validationFormData={mockFormData}
             onSubmit={handleSubmit}
-            onClose={jest.fn()}
           />
         </IntlProviderDouble>
       </AppConfigurationProvider>
@@ -144,7 +142,6 @@ describe("ValidateSubscribersFormComponent", () => {
       <IntlProviderDouble>
         <ValidateMaxSubscribersForm
           validationFormData={mockFormData}
-          onClose={jest.fn()}
           onSubmit={jest.fn()}
         />
       </IntlProviderDouble>
@@ -164,7 +161,6 @@ describe("ValidateSubscribersFormComponent", () => {
       <IntlProviderDouble>
         <ValidateMaxSubscribersForm
           validationFormData={mockFormData}
-          onClose={jest.fn()}
           onSubmit={jest.fn()}
         />
       </IntlProviderDouble>

--- a/src/components/ValidateSubscriber/ValidateMaxSubscribersForm.tsx
+++ b/src/components/ValidateSubscriber/ValidateMaxSubscribersForm.tsx
@@ -2,29 +2,28 @@ import React, { ReactNode } from "react";
 import { Form, Formik, FormikState } from "formik";
 import { FormattedMessage } from "react-intl";
 import { FieldGroup, SubmitButton } from "./form-helpers";
-import {
-  MaxSubscribersData,
-  MaxSubscribersQuestion,
-  SubscriberValidationAnswer,
-} from "./types";
+import { QuestionModel, AnswerModel } from "./types";
 import { Question } from "./Question";
+import { Loading } from "../Loading";
 
 export interface ValidateMaxSubscribersFormProp {
-  validationFormData: MaxSubscribersData;
+  questions: QuestionModel[];
   onSubmit: () => Promise<boolean>;
   customSubmit?: ReactNode;
+  className?: string;
 }
 
 export const ValidateMaxSubscribersForm = ({
-  validationFormData,
+  questions,
   onSubmit,
   customSubmit,
+  ...otherProps
 }: ValidateMaxSubscribersFormProp) => {
-  const isCheckbox = (answer: SubscriberValidationAnswer) => {
+  const isCheckbox = (answer: AnswerModel) => {
     return ["CHECKBOX_WITH_TEXTAREA", "CHECKBOX"].includes(answer.answerType);
   };
 
-  const normalizeQuestions = (questionsList: MaxSubscribersQuestion[]) => {
+  const normalizeQuestions = (questionsList: QuestionModel[]) => {
     let normalizedAnswer: any = {};
     questionsList?.forEach((question, index) => {
       normalizedAnswer[`answer${index}`] = isCheckbox(question.answer)
@@ -37,10 +36,10 @@ export const ValidateMaxSubscribersForm = ({
     return normalizedAnswer;
   };
 
-  const answers: any = normalizeQuestions(validationFormData.questionsList);
+  const answers: any = normalizeQuestions(questions);
 
   const handlerSubmit = async (values: any, { setSubmitting }: any) => {
-    validationFormData.questionsList.forEach((questionItem, index) => {
+    questions.forEach((questionItem, index) => {
       if (isCheckbox(questionItem.answer)) {
         questionItem.answer.value = values[`answer${index}`].join("-");
         questionItem.answer.text = values[`answer${index}_text`];
@@ -56,16 +55,20 @@ export const ValidateMaxSubscribersForm = ({
 
   const validate = (values: any) => {
     const errors: any = {};
-    for (let value in values) {
-      if (Array.isArray(values[value]) && values[value].length === 0) {
-        errors[value] = "validate_max_subscribers_form.checkbox_empty";
+    for (let attr in values) {
+      if (
+        values.hasOwnProperty(attr) &&
+        Array.isArray(values[attr]) &&
+        values[attr].length === 0
+      ) {
+        errors[attr] = "validate_max_subscribers_form.checkbox_empty";
       }
     }
     return errors;
   };
 
   const renderQuestions = (
-    questionItem: MaxSubscribersQuestion,
+    questionItem: QuestionModel,
     questionIndex: number,
     formikProps: FormikState<any>
   ) => {
@@ -85,54 +88,38 @@ export const ValidateMaxSubscribersForm = ({
   };
 
   if (Object.entries(answers).length === 0) {
-    return <>Loading..</>;
+    return <Loading />;
   }
 
   return (
-    <section className="dp-container">
-      <div className="dp-wrapper-form-plans">
-        <h2 className="modal-title">
-          <FormattedMessage id="validate_max_subscribers_form.title" />
-        </h2>
-        <p>
-          <FormattedMessage id="validate_max_subscribers_form.subtitle" />
-        </p>
-        <Formik
-          initialValues={answers}
-          validate={validate}
-          onSubmit={handlerSubmit}
-        >
-          {(formikProps) => (
-            <Form className="dp-validate-max-subscribers">
-              <fieldset>
-                <legend>
-                  <FormattedMessage id="validate_max_subscribers_form.title" />
-                </legend>
-                <FieldGroup>
-                  {validationFormData.questionsList?.map(
-                    (questionItem, questionIndex) => (
-                      <React.Fragment key={`question${questionIndex}`}>
-                        {renderQuestions(
-                          questionItem,
-                          questionIndex,
-                          formikProps
-                        )}
-                      </React.Fragment>
-                    )
-                  )}
-                </FieldGroup>
-                {customSubmit ? (
-                  customSubmit
-                ) : (
-                  <SubmitButton className="dp-button button-medium primary-green">
-                    <FormattedMessage id="common.save" />
-                  </SubmitButton>
-                )}
-              </fieldset>
-            </Form>
-          )}
-        </Formik>
-      </div>
-    </section>
+    <Formik
+      initialValues={answers}
+      validate={validate}
+      onSubmit={handlerSubmit}
+    >
+      {(formikProps) => (
+        <Form {...otherProps}>
+          <fieldset>
+            <legend>
+              <FormattedMessage id="validate_max_subscribers_form.title" />
+            </legend>
+            <FieldGroup>
+              {questions?.map((questionItem, questionIndex) => (
+                <React.Fragment key={`question${questionIndex}`}>
+                  {renderQuestions(questionItem, questionIndex, formikProps)}
+                </React.Fragment>
+              ))}
+            </FieldGroup>
+            {customSubmit ? (
+              customSubmit
+            ) : (
+              <SubmitButton className="dp-button button-medium primary-green">
+                <FormattedMessage id="common.save" />
+              </SubmitButton>
+            )}
+          </fieldset>
+        </Form>
+      )}
+    </Formik>
   );
 };

--- a/src/components/ValidateSubscriber/ValidateMaxSubscribersForm.tsx
+++ b/src/components/ValidateSubscriber/ValidateMaxSubscribersForm.tsx
@@ -1,25 +1,19 @@
-import React, { useState } from "react";
-import { Field, Form, Formik, FormikState } from "formik";
+import React from "react";
+import { Form, Formik, FormikState } from "formik";
 import { FormattedMessage } from "react-intl";
-import {
-  CheckboxFieldItem,
-  FieldGroup,
-  InputFieldItem,
-  SubmitButton,
-} from "./form-helpers";
+import { FieldGroup, SubmitButton } from "./form-helpers";
 import {
   MaxSubscribersQuestion,
   SubscriberValidationAnswer,
   ValidateMaxSubscribersFormProp,
 } from "./types";
+import { Question } from "./Question";
 
 export const ValidateMaxSubscribersForm = ({
   validationFormData,
   handleClose,
   handleSubmit,
 }: ValidateMaxSubscribersFormProp) => {
-  const [show, setShow] = useState(false);
-
   const isCheckbox = (answer: SubscriberValidationAnswer) => {
     return ["CHECKBOX_WITH_TEXTAREA", "CHECKBOX"].includes(answer.answerType);
   };
@@ -70,83 +64,18 @@ export const ValidateMaxSubscribersForm = ({
     formikProps: FormikState<any>
   ) => {
     const { touched, errors, submitCount } = formikProps;
-    if (
-      questionItem.answer?.answerType === "TEXTFIELD" ||
-      questionItem.answer?.answerType === "URL"
-    ) {
-      return (
-        <InputFieldItem
-          type="text"
-          label={questionItem.question}
-          fieldName={`answer${questionIndex}`}
-          required
-          className={`${
-            questionItem.answer?.answerType === "TEXTFIELD"
-              ? "field-item--50"
-              : ""
-          }`}
-        />
-      );
-    }
-
-    if (isCheckbox(questionItem.answer)) {
-      const fieldName = `answer${questionIndex}`;
-      return (
-        <li className="m-t-6">
-          <fieldset>
-            <label htmlFor={questionItem.question}>
-              {questionItem.question}
-            </label>
-            <FieldGroup>
-              {questionItem.answer.answerOptions.map((option, optionIndex) => {
-                const lastCheckboxItem =
-                  questionItem.answer?.answerType ===
-                    "CHECKBOX_WITH_TEXTAREA" &&
-                  questionItem.answer?.answerOptions.length - 1 === optionIndex;
-                return (
-                  <React.Fragment key={`checkbox${optionIndex}`}>
-                    <CheckboxFieldItem
-                      className={"field-item--50"}
-                      label={option}
-                      fieldName={fieldName}
-                      id={`${fieldName}-${optionIndex}`}
-                      value={option}
-                      onClick={lastCheckboxItem ? toggleOthers : undefined}
-                      withErrors={false}
-                    />
-                    {lastCheckboxItem ? (
-                      <div
-                        className={`${show ? "dp-show" : "dp-hide"}`}
-                        data-testid="last-textarea"
-                      >
-                        <Field
-                          as="textarea"
-                          name={`answer${questionIndex}_text`}
-                          className={"field-item"}
-                        />
-                      </div>
-                    ) : null}
-                  </React.Fragment>
-                );
-              })}
-              {submitCount && touched[fieldName] && errors[fieldName] ? (
-                <li className="field-item error">
-                  <div className="dp-message dp-error-form">
-                    <p>
-                      <FormattedMessage id={`${errors[fieldName]}`} />
-                    </p>
-                  </div>
-                </li>
-              ) : null}
-            </FieldGroup>
-          </fieldset>
-        </li>
-      );
-    }
-  };
-
-  const toggleOthers = () => {
-    setShow(!show);
+    const fieldName = `answer${questionIndex}`;
+    return (
+      <Question
+        questionItem={questionItem}
+        fieldName={fieldName}
+        error={
+          submitCount && touched[fieldName] && errors[fieldName]
+            ? `${errors[fieldName]}`
+            : undefined
+        }
+      />
+    );
   };
 
   if (Object.entries(answers).length === 0) {

--- a/src/components/ValidateSubscriber/ValidateMaxSubscribersForm.tsx
+++ b/src/components/ValidateSubscriber/ValidateMaxSubscribersForm.tsx
@@ -11,8 +11,8 @@ import { Question } from "./Question";
 
 export const ValidateMaxSubscribersForm = ({
   validationFormData,
-  handleClose,
-  handleSubmit,
+  onClose,
+  onSubmit,
 }: ValidateMaxSubscribersFormProp) => {
   const isCheckbox = (answer: SubscriberValidationAnswer) => {
     return ["CHECKBOX_WITH_TEXTAREA", "CHECKBOX"].includes(answer.answerType);
@@ -33,7 +33,7 @@ export const ValidateMaxSubscribersForm = ({
 
   const answers: any = normalizeQuestions(validationFormData.questionsList);
 
-  const onSubmit = async (values: any, { setSubmitting }: any) => {
+  const handlerSubmit = async (values: any, { setSubmitting }: any) => {
     validationFormData.questionsList.forEach((questionItem, index) => {
       if (isCheckbox(questionItem.answer)) {
         questionItem.answer.value = values[`answer${index}`].join("-");
@@ -42,7 +42,7 @@ export const ValidateMaxSubscribersForm = ({
         questionItem.answer.value = values[`answer${index}`];
       }
     });
-    const result = await handleSubmit();
+    const result = await onSubmit();
     if (!result) {
       setSubmitting(false);
     }
@@ -91,7 +91,11 @@ export const ValidateMaxSubscribersForm = ({
         <p>
           <FormattedMessage id="validate_max_subscribers_form.subtitle" />
         </p>
-        <Formik initialValues={answers} validate={validate} onSubmit={onSubmit}>
+        <Formik
+          initialValues={answers}
+          validate={validate}
+          onSubmit={handlerSubmit}
+        >
           {(formikProps) => (
             <Form className="dp-validate-max-subscribers">
               <fieldset>
@@ -131,7 +135,7 @@ export const ValidateMaxSubscribersForm = ({
                       <button
                         type="button"
                         className="dp-button button-medium primary-grey m-r-6"
-                        onClick={handleClose}
+                        onClick={onClose}
                       >
                         <FormattedMessage id="common.cancel" />
                       </button>

--- a/src/components/ValidateSubscriber/ValidateMaxSubscribersForm.tsx
+++ b/src/components/ValidateSubscriber/ValidateMaxSubscribersForm.tsx
@@ -1,18 +1,24 @@
-import React from "react";
+import React, { ReactNode } from "react";
 import { Form, Formik, FormikState } from "formik";
 import { FormattedMessage } from "react-intl";
 import { FieldGroup, SubmitButton } from "./form-helpers";
 import {
+  MaxSubscribersData,
   MaxSubscribersQuestion,
   SubscriberValidationAnswer,
-  ValidateMaxSubscribersFormProp,
 } from "./types";
 import { Question } from "./Question";
 
+export interface ValidateMaxSubscribersFormProp {
+  validationFormData: MaxSubscribersData;
+  onSubmit: () => Promise<boolean>;
+  customSubmit?: ReactNode;
+}
+
 export const ValidateMaxSubscribersForm = ({
   validationFormData,
-  onClose,
   onSubmit,
+  customSubmit,
 }: ValidateMaxSubscribersFormProp) => {
   const isCheckbox = (answer: SubscriberValidationAnswer) => {
     return ["CHECKBOX_WITH_TEXTAREA", "CHECKBOX"].includes(answer.answerType);
@@ -115,36 +121,13 @@ export const ValidateMaxSubscribersForm = ({
                     )
                   )}
                 </FieldGroup>
-                <p>
-                  <i>
-                    <FormattedMessage id="validate_max_subscribers_form.form_help" />{" "}
-                    <a
-                      target="_BLANK"
-                      rel="noreferrer"
-                      href={validationFormData?.urlHelp}
-                    >
-                      <FormattedMessage id="validate_max_subscribers_form.form_help_link_text" />
-                      <br />
-                    </a>
-                    <FormattedMessage id="validate_max_subscribers_form.info_text" />
-                  </i>
-                </p>
-                <div className="dp-container">
-                  <div className="dp-rowflex">
-                    <div className="dp-footer-form">
-                      <button
-                        type="button"
-                        className="dp-button button-medium primary-grey m-r-6"
-                        onClick={onClose}
-                      >
-                        <FormattedMessage id="common.cancel" />
-                      </button>
-                      <SubmitButton className="dp-button button-medium primary-green">
-                        <FormattedMessage id="common.save" />
-                      </SubmitButton>
-                    </div>
-                  </div>
-                </div>
+                {customSubmit ? (
+                  customSubmit
+                ) : (
+                  <SubmitButton className="dp-button button-medium primary-green">
+                    <FormattedMessage id="common.save" />
+                  </SubmitButton>
+                )}
               </fieldset>
             </Form>
           )}

--- a/src/components/ValidateSubscriber/ValidateSubscribers.test.tsx
+++ b/src/components/ValidateSubscriber/ValidateSubscribers.test.tsx
@@ -5,7 +5,7 @@ import {
   waitForElementToBeRemoved,
 } from "@testing-library/react";
 import { IntlProviderDouble } from "../i18n/DopplerIntlProvider.double-with-ids-as-values";
-import { ValidateSubscribers } from "./ValidateSubscribers";
+import { ValidateSubscribersForm } from "./ValidateSubscribersForm";
 import * as dopplerLegacyClient from "../../client/dopplerLegacyClient";
 import userEvent from "@testing-library/user-event";
 import { AnswerType, MaxSubscribersData } from "./types";
@@ -16,7 +16,7 @@ export const maxSubscribersData: MaxSubscribersData = {
   questionsList: [
     {
       answer: {
-        answerType: AnswerType[1],
+        answerType: `${AnswerType.TEXTFIELD}`,
         answerOptions: [],
         value: "",
         optionsSelected: [],
@@ -25,7 +25,7 @@ export const maxSubscribersData: MaxSubscribersData = {
     },
     {
       answer: {
-        answerType: AnswerType[1],
+        answerType: `${AnswerType.TEXTFIELD}`,
         answerOptions: [],
         value: "",
         optionsSelected: [],
@@ -34,7 +34,7 @@ export const maxSubscribersData: MaxSubscribersData = {
     },
     {
       answer: {
-        answerType: AnswerType[1],
+        answerType: `${AnswerType.TEXTFIELD}`,
         answerOptions: [],
         value: "",
         optionsSelected: [],
@@ -43,7 +43,7 @@ export const maxSubscribersData: MaxSubscribersData = {
     },
     {
       answer: {
-        answerType: AnswerType[1],
+        answerType: `${AnswerType.TEXTFIELD}`,
         answerOptions: [],
         value: "",
         optionsSelected: [],
@@ -52,7 +52,7 @@ export const maxSubscribersData: MaxSubscribersData = {
     },
     {
       answer: {
-        answerType: AnswerType[3],
+        answerType: `${AnswerType.TEXTFIELD}`,
         answerOptions: [
           "Sitio Web",
           "Evento",
@@ -69,7 +69,7 @@ export const maxSubscribersData: MaxSubscribersData = {
     },
     {
       answer: {
-        answerType: AnswerType[2],
+        answerType: `${AnswerType.TEXTFIELD}`,
         answerOptions: ["Opt-in", "Doble Opt-in", "Manual"],
         value: "",
         optionsSelected: [],
@@ -78,7 +78,7 @@ export const maxSubscribersData: MaxSubscribersData = {
     },
     {
       answer: {
-        answerType: AnswerType[6],
+        answerType: `${AnswerType.TEXTFIELD}`,
         answerOptions: [],
         value: "",
         optionsSelected: [],
@@ -88,8 +88,7 @@ export const maxSubscribersData: MaxSubscribersData = {
   ],
   isSentSuccessEmail: false,
   urlReferrer: "",
-  urlHelp:
-    "http://help.fromdoppler.com/por-que-debo-completar-un-formulario-al-cargar-mis-listas/",
+  urlHelp: "https://help.fromdoppler.com/",
 };
 
 describe("ValidateSubscribersComponent", () => {
@@ -99,7 +98,7 @@ describe("ValidateSubscribersComponent", () => {
     render(
       <QueryClientProvider client={queryClient}>
         <IntlProviderDouble>
-          <ValidateSubscribers handleClose={jest.fn} />
+          <ValidateSubscribersForm handleClose={jest.fn} />
         </IntlProviderDouble>
       </QueryClientProvider>
     );
@@ -126,7 +125,7 @@ describe("ValidateSubscribersComponent", () => {
     render(
       <QueryClientProvider client={queryClient}>
         <IntlProviderDouble>
-          <ValidateSubscribers handleClose={jest.fn} />
+          <ValidateSubscribersForm handleClose={jest.fn} />
         </IntlProviderDouble>
       </QueryClientProvider>
     );
@@ -143,7 +142,7 @@ describe("ValidateSubscribersComponent", () => {
       .mockImplementation(() => ({
         getMaxSubscribersData: jest.fn(async () => maxSubscribersData),
         sendAcceptButtonAction: jest.fn(),
-        sendMaxSubscribersData: jest.fn(async (data) => true),
+        sendMaxSubscribersData: jest.fn(async () => true),
       }));
 
     const queryClient = new QueryClient();
@@ -152,7 +151,7 @@ describe("ValidateSubscribersComponent", () => {
       <QueryClientProvider client={queryClient}>
         <AppConfigurationProvider configuration={{ useDummies: true }}>
           <IntlProviderDouble>
-            <ValidateSubscribers handleClose={jest.fn} />
+            <ValidateSubscribersForm handleClose={jest.fn} />
           </IntlProviderDouble>
         </AppConfigurationProvider>
       </QueryClientProvider>
@@ -179,8 +178,7 @@ describe("ValidateSubscribersComponent", () => {
       ],
       isSentSuccessEmail: false,
       urlReferrer: "",
-      urlHelp:
-        "http://help.fromdoppler.com/por-que-debo-completar-un-formulario-al-cargar-mis-listas/",
+      urlHelp: "https://help.fromdoppler.com/",
     };
 
     jest
@@ -188,7 +186,7 @@ describe("ValidateSubscribersComponent", () => {
       .mockImplementation(() => ({
         getMaxSubscribersData: jest.fn(async () => formData),
         sendAcceptButtonAction: jest.fn(),
-        sendMaxSubscribersData: jest.fn(async (data) => true),
+        sendMaxSubscribersData: jest.fn(async () => true),
       }));
 
     const queryClient = new QueryClient();
@@ -196,7 +194,7 @@ describe("ValidateSubscribersComponent", () => {
     render(
       <QueryClientProvider client={queryClient}>
         <IntlProviderDouble>
-          <ValidateSubscribers handleClose={jest.fn} />
+          <ValidateSubscribersForm handleClose={jest.fn} />
         </IntlProviderDouble>
       </QueryClientProvider>
     );

--- a/src/components/ValidateSubscriber/ValidateSubscribers.test.tsx
+++ b/src/components/ValidateSubscriber/ValidateSubscribers.test.tsx
@@ -99,7 +99,7 @@ describe("ValidateSubscribersComponent", () => {
     render(
       <QueryClientProvider client={queryClient}>
         <IntlProviderDouble>
-          <ValidateSubscribers handleClose={jest.fn} setNextAlert={jest.fn} />
+          <ValidateSubscribers handleClose={jest.fn} />
         </IntlProviderDouble>
       </QueryClientProvider>
     );
@@ -126,7 +126,7 @@ describe("ValidateSubscribersComponent", () => {
     render(
       <QueryClientProvider client={queryClient}>
         <IntlProviderDouble>
-          <ValidateSubscribers handleClose={jest.fn} setNextAlert={jest.fn} />
+          <ValidateSubscribers handleClose={jest.fn} />
         </IntlProviderDouble>
       </QueryClientProvider>
     );
@@ -152,7 +152,7 @@ describe("ValidateSubscribersComponent", () => {
       <QueryClientProvider client={queryClient}>
         <AppConfigurationProvider configuration={{ useDummies: true }}>
           <IntlProviderDouble>
-            <ValidateSubscribers handleClose={jest.fn} setNextAlert={jest.fn} />
+            <ValidateSubscribers handleClose={jest.fn} />
           </IntlProviderDouble>
         </AppConfigurationProvider>
       </QueryClientProvider>
@@ -196,7 +196,7 @@ describe("ValidateSubscribersComponent", () => {
     render(
       <QueryClientProvider client={queryClient}>
         <IntlProviderDouble>
-          <ValidateSubscribers handleClose={jest.fn} setNextAlert={jest.fn} />
+          <ValidateSubscribers handleClose={jest.fn} />
         </IntlProviderDouble>
       </QueryClientProvider>
     );

--- a/src/components/ValidateSubscriber/ValidateSubscribers.tsx
+++ b/src/components/ValidateSubscriber/ValidateSubscribers.tsx
@@ -1,10 +1,12 @@
-import { useState } from "react";
+import React, { useState } from "react";
 import { Loading } from "../Loading";
 import { ValidateMaxSubscribersForm } from "./ValidateMaxSubscribersForm";
 import { ValidateMaxSubscribersConfirmation } from "./ValidateMaxSubscribersConfirmation";
 import { UnexpectedError } from "../UnexpectedError";
 import { useDopplerLegacyClient } from "../../client/dopplerLegacyClient";
 import { useQuery } from "react-query";
+import { FormattedMessage } from "react-intl";
+import { SubmitButton } from "./form-helpers";
 
 interface ValidateSubscribersProps {
   handleClose: () => void;
@@ -52,11 +54,46 @@ export const ValidateSubscribers = ({
     return <ValidateMaxSubscribersConfirmation handleClose={handleClose} />;
   }
 
+  const customSubmit = (
+    <>
+      <p>
+        <i>
+          <FormattedMessage id="validate_max_subscribers_form.form_help" />{" "}
+          <a
+            target="_BLANK"
+            rel="noreferrer"
+            href={validationFormData?.urlHelp}
+          >
+            <FormattedMessage id="validate_max_subscribers_form.form_help_link_text" />
+            <br />
+          </a>
+          <FormattedMessage id="validate_max_subscribers_form.info_text" />
+        </i>
+      </p>
+      <div className="dp-container">
+        <div className="dp-rowflex">
+          <div className="dp-footer-form">
+            <button
+              type="button"
+              className="dp-button button-medium primary-grey m-r-6"
+              onClick={handleClose}
+            >
+              <FormattedMessage id="common.cancel" />
+            </button>
+            <SubmitButton className="dp-button button-medium primary-green">
+              <FormattedMessage id="common.save" />
+            </SubmitButton>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+
   return (
     <ValidateMaxSubscribersForm
       validationFormData={validationFormData}
-      onClose={handleClose}
       onSubmit={handleSubmit}
+      customSubmit={customSubmit}
     />
   );
 };

--- a/src/components/ValidateSubscriber/ValidateSubscribers.tsx
+++ b/src/components/ValidateSubscriber/ValidateSubscribers.tsx
@@ -7,6 +7,7 @@ import { useDopplerLegacyClient } from "../../client/dopplerLegacyClient";
 import { useQuery } from "react-query";
 import { FormattedMessage } from "react-intl";
 import { SubmitButton } from "./form-helpers";
+import { MaxSubscribersData } from "./types";
 
 interface ValidateSubscribersProps {
   handleClose: () => void;
@@ -20,7 +21,7 @@ export const ValidateSubscribers = ({
     data: validationFormData,
     isLoading,
     error,
-  } = useQuery<any>(
+  } = useQuery<MaxSubscribersData>(
     "getMaxSubscribersData",
     dopplerLegacyClient.getMaxSubscribersData,
     {
@@ -33,9 +34,10 @@ export const ValidateSubscribers = ({
   const [success, setSuccess] = useState(false);
 
   const handleSubmit = async () => {
-    const isSuccess = await dopplerLegacyClient.sendMaxSubscribersData(
-      validationFormData
-    );
+    // TODO: improve that, never occur if validationFormData is undefined
+    const isSuccess = validationFormData
+      ? await dopplerLegacyClient.sendMaxSubscribersData(validationFormData)
+      : false;
     if (isSuccess) {
       setSuccess(isSuccess);
     }
@@ -90,10 +92,23 @@ export const ValidateSubscribers = ({
   );
 
   return (
-    <ValidateMaxSubscribersForm
-      validationFormData={validationFormData}
-      onSubmit={handleSubmit}
-      customSubmit={customSubmit}
-    />
+    <section className="dp-container">
+      <div className="dp-wrapper-form-plans">
+        <h2 className="modal-title">
+          <FormattedMessage id="validate_max_subscribers_form.title" />
+        </h2>
+        <p>
+          <FormattedMessage id="validate_max_subscribers_form.subtitle" />
+        </p>
+        {validationFormData && (
+          <ValidateMaxSubscribersForm
+            questions={validationFormData.questionsList}
+            onSubmit={handleSubmit}
+            customSubmit={customSubmit}
+            className="dp-validate-max-subscribers"
+          />
+        )}
+      </div>
+    </section>
   );
 };

--- a/src/components/ValidateSubscriber/ValidateSubscribers.tsx
+++ b/src/components/ValidateSubscriber/ValidateSubscribers.tsx
@@ -8,12 +8,10 @@ import { useQuery } from "react-query";
 
 interface ValidateSubscribersProps {
   handleClose: () => void;
-  setNextAlert: () => void;
 }
 
 export const ValidateSubscribers = ({
   handleClose,
-  setNextAlert,
 }: ValidateSubscribersProps) => {
   const dopplerLegacyClient = useDopplerLegacyClient();
   const {
@@ -38,7 +36,6 @@ export const ValidateSubscribers = ({
     );
     if (isSuccess) {
       setSuccess(isSuccess);
-      setNextAlert();
     }
     return isSuccess;
   };
@@ -58,8 +55,8 @@ export const ValidateSubscribers = ({
   return (
     <ValidateMaxSubscribersForm
       validationFormData={validationFormData}
-      handleClose={handleClose}
-      handleSubmit={handleSubmit}
+      onClose={handleClose}
+      onSubmit={handleSubmit}
     />
   );
 };

--- a/src/components/ValidateSubscriber/ValidateSubscribersForm.tsx
+++ b/src/components/ValidateSubscriber/ValidateSubscribersForm.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import { Loading } from "../Loading";
-import { ValidateMaxSubscribersForm } from "./ValidateMaxSubscribersForm";
+import { QuestionsForm } from "./QuestionsForm";
 import { ValidateMaxSubscribersConfirmation } from "./ValidateMaxSubscribersConfirmation";
 import { UnexpectedError } from "../UnexpectedError";
 import { useDopplerLegacyClient } from "../../client/dopplerLegacyClient";
@@ -13,7 +13,7 @@ interface ValidateSubscribersProps {
   handleClose: () => void;
 }
 
-export const ValidateSubscribers = ({
+export const ValidateSubscribersForm = ({
   handleClose,
 }: ValidateSubscribersProps) => {
   const dopplerLegacyClient = useDopplerLegacyClient();
@@ -101,7 +101,7 @@ export const ValidateSubscribers = ({
           <FormattedMessage id="validate_max_subscribers_form.subtitle" />
         </p>
         {validationFormData && (
-          <ValidateMaxSubscribersForm
+          <QuestionsForm
             questions={validationFormData.questionsList}
             onSubmit={handleSubmit}
             customSubmit={customSubmit}

--- a/src/components/ValidateSubscriber/form-helpers.tsx
+++ b/src/components/ValidateSubscriber/form-helpers.tsx
@@ -142,9 +142,7 @@ export const InputFieldItem = ({
   type,
   placeholder,
   required,
-  withNameValidation,
-  minLength,
-  rest,
+  ...rest
 }: InputFieldItemProp) => (
   <FieldItem
     className={concatClasses("field-item", className)}

--- a/src/components/ValidateSubscriber/types.ts
+++ b/src/components/ValidateSubscriber/types.ts
@@ -1,16 +1,16 @@
 export interface MaxSubscribersData {
   isSentSuccessEmail: boolean;
-  questionsList: MaxSubscribersQuestion[];
+  questionsList: QuestionModel[];
   urlHelp: string;
   urlReferrer: string;
 }
 
-export interface MaxSubscribersQuestion {
+export interface QuestionModel {
   question: string;
-  answer: SubscriberValidationAnswer;
+  answer: AnswerModel;
 }
 
-export interface SubscriberValidationAnswer {
+export interface AnswerModel {
   answerType: string;
   answerOptions: string[];
   value: string;

--- a/src/components/ValidateSubscriber/types.ts
+++ b/src/components/ValidateSubscriber/types.ts
@@ -29,6 +29,6 @@ export enum AnswerType {
 
 export interface ValidateMaxSubscribersFormProp {
   validationFormData: MaxSubscribersData;
-  handleClose: () => void;
-  handleSubmit: () => Promise<boolean>;
+  onClose: () => void;
+  onSubmit: () => Promise<boolean>;
 }

--- a/src/components/ValidateSubscriber/types.ts
+++ b/src/components/ValidateSubscriber/types.ts
@@ -26,9 +26,3 @@ export enum AnswerType {
   RADIOBUTTON = 5,
   URL = 6,
 }
-
-export interface ValidateMaxSubscribersFormProp {
-  validationFormData: MaxSubscribersData;
-  onClose: () => void;
-  onSubmit: () => Promise<boolean>;
-}


### PR DESCRIPTION
Refactorización del formulario de suscriptores manteniendo la lógica  extraída de [doppler-webapp](https://github.com/FromDoppler/doppler-webapp).

- Se separó los componentes de preguntas en `InputQuestion `y `CheckboxQuestion`.
- Se simplificó los tipos de componente usando `Question`, este decide que tipo de componente renderizar en base al tipo de pregunta.
- Se aisló y renombraron <s>`ValidateMaxSubscriberForm `</s> por `QuestionForm`
- Se renombraron <s>`ValidateSubscriber `</s> a `ValidateSubscriberForm `ahora este pasa a construir el formulario usando `QuestionForm`
- Se renombraron algunos modelos del _Typado_ del formulario.
- Se actualizaron las pruebas de `HeaderMessages`