### PR TITLE
[DE-726] refactorización de componente plan de usuario

### DIFF
--- a/src/components/ClientManagerUserPlan.tsx
+++ b/src/components/ClientManagerUserPlan.tsx
@@ -1,0 +1,24 @@
+import { FormattedMessage } from "react-intl";
+
+export const ClientManagerUserPlan = ({
+  profileName,
+}: {
+  profileName?: string;
+}) => (
+  <div className="user-plan--type">
+    {profileName ? (
+      <p className="user-plan--monthly-text">
+        <FormattedMessage id="header.profile" /> <strong>{profileName}</strong>
+      </p>
+    ) : (
+      <>
+        <p className="user-plan--monthly-text">
+          <FormattedMessage id="header.send_mails" />
+        </p>
+        <p className="user-plan-enabled">
+          <FormattedMessage id="header.enabled" />
+        </p>
+      </>
+    )}
+  </div>
+);

--- a/src/components/HeaderMessages.test.tsx
+++ b/src/components/HeaderMessages.test.tsx
@@ -77,7 +77,7 @@ describe("<HeaderMessages />", () => {
   );
 
   it("display a button if url property is undefined and action is validateSubscribersPopup", async () => {
-    const modalTestId = "modal";
+    const modalTestId = "validate.subscribe.modal";
     const alertData: Alert = {
       type: "warning",
       message: "test--message",

--- a/src/components/HeaderMessages.tsx
+++ b/src/components/HeaderMessages.tsx
@@ -59,6 +59,7 @@ export const HeaderMessages = ({ alert, user }: HeaderMessagesProp) => {
           type={
             button?.action === validateSubscribersPopup ? "large" : "medium"
           }
+          data-testid={"validate.subscribe.modal"}
         >
           {button?.action === validateSubscribersPopup ? (
             <ValidateSubscribersForm

--- a/src/components/Modal.test.tsx
+++ b/src/components/Modal.test.tsx
@@ -11,7 +11,12 @@ const toggleModal = jest.fn();
 describe("<Modal />", () => {
   it("renders Modal component", async () => {
     render(
-      <Modal isOpen={true} children={content} handleClose={toggleModal} />
+      <Modal
+        isOpen={true}
+        children={content}
+        handleClose={toggleModal}
+        data-testid="modal"
+      />
     );
 
     const modal = screen.getByTestId(modalTestId);

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -3,6 +3,7 @@ interface ModalProp {
   type?: string;
   handleClose: () => void;
   children: React.ReactNode;
+  "data-testid"?: string;
 }
 
 export const Modal = ({
@@ -10,13 +11,14 @@ export const Modal = ({
   type = "medium",
   handleClose,
   children,
+  ...otherProps
 }: ModalProp) => {
   if (!isOpen) {
     return null;
   }
 
   return (
-    <div className="modal" data-testid="modal">
+    <div className="modal" {...otherProps}>
       <div className={`modal-content--${type}`}>
         <span
           onClick={handleClose}

--- a/src/components/UserMenu.tsx
+++ b/src/components/UserMenu.tsx
@@ -3,6 +3,7 @@ import useOnclickOutside from "react-cool-onclickoutside";
 import { User } from "../model";
 import { Avatar } from "./Avatar";
 import { UserPlan } from "./UserPlan";
+import { ClientManagerUserPlan } from "./ClientManagerUserPlan";
 
 interface UserMenuProps {
   user: User;
@@ -38,7 +39,11 @@ export const UserMenu = ({ user }: UserMenuProps) => {
             <span className="email">{email}</span>
           </p>
         </header>
-        <UserPlan user={user} />
+        {user.hasClientManager ? (
+          <ClientManagerUserPlan profileName={user.clientManager.profileName} />
+        ) : (
+          <UserPlan user={user} />
+        )}
         <ul className="options-user">
           {navItems.map((item, index) => (
             <li key={index}>

--- a/src/components/UserPlan.test.tsx
+++ b/src/components/UserPlan.test.tsx
@@ -16,15 +16,11 @@ describe(UserPlan.name, () => {
     );
 
     // Assert
-    expect(screen.getByText(defaultUser.plan.planName)).toBeInTheDocument();
-    expect(
-      screen.getByText(defaultUser.plan.maxSubscribers)
-    ).toBeInTheDocument();
-    expect(screen.getByText(defaultUser.plan.buttonText)).toBeInTheDocument();
-    expect(
-      screen.getByText(defaultUser.plan.remainingCredits)
-    ).toBeInTheDocument();
-    expect(screen.getByText(defaultUser.plan.description)).toBeInTheDocument();
+    screen.getByText(defaultUser.plan.planName);
+    screen.getByText(defaultUser.plan.maxSubscribers);
+    screen.getByText(defaultUser.plan.buttonText);
+    screen.getByText(defaultUser.plan.remainingCredits);
+    screen.getByText(defaultUser.plan.description);
   });
 
   it("should display the user's monthly plan information.", () => {

--- a/src/components/UserPlan.test.tsx
+++ b/src/components/UserPlan.test.tsx
@@ -159,7 +159,7 @@ describe(UserPlan.name, () => {
         ...defaultUser.plan,
         pendingFreeUpgrade: false,
         buttonUrl: "upgrade/link/to/test",
-        buttonText
+        buttonText,
       },
     };
 

--- a/src/components/UserPlan.test.tsx
+++ b/src/components/UserPlan.test.tsx
@@ -151,57 +151,69 @@ describe(UserPlan.name, () => {
     screen.getByTestId(modalTestId);
   });
 
-  it("should render an Upgrade link when plan has a button url and no pending free upgrade", () => {
+  it("should display plan link when plan no pending for upgrade", () => {
+    const buttonText = "no.pending.for.upgrade";
     const upgradeLinkPlanUser: User = {
       ...defaultUser,
       plan: {
         ...defaultUser.plan,
         pendingFreeUpgrade: false,
         buttonUrl: "upgrade/link/to/test",
+        buttonText
       },
     };
-    const upgradeLabel = "UPGRADE";
 
     // Act
     render(
-      <MenuIntlProvider>
+      <IntlProviderDouble>
         <UserPlan user={upgradeLinkPlanUser} />
-      </MenuIntlProvider>
+      </IntlProviderDouble>
     );
 
     // Assert
-    const upgradeLink = screen.getByText(upgradeLabel);
+    const upgradeLink = screen.getByText(buttonText);
     expect(upgradeLink).toHaveAttribute(
       "href",
       upgradeLinkPlanUser.plan.buttonUrl
     );
   });
 
-  it("should render a button with tooltip when upgrade request was sent", () => {
+  it("should display button with tip when upgrade request was sent", () => {
     // Arrange
     const tooltipPlanUser: User = {
       ...defaultUser,
       isLastPlanRequested: true,
-      plan: {
-        ...defaultUser.plan,
-      },
     };
-    const requestSentLabel = "SOLICITUD ENVIADA";
 
     // Act
     render(
-      <MenuIntlProvider>
+      <IntlProviderDouble>
         <UserPlan user={tooltipPlanUser} />
-      </MenuIntlProvider>
+      </IntlProviderDouble>
     );
 
-    const requestSentButton = screen.getByText(requestSentLabel);
-    const tooltip = screen.getByText(
-      "Estamos diseñando un Plan a la medida de tus necesidades. ¡Te contactaremos pronto!"
+    screen.getByText("header.send_request");
+    screen.getByText("header.tooltip_last_plan");
+  });
+
+  it("don't should display button with tip when upgrade request wasn't sent", () => {
+    // Arrange
+    const tooltipPlanUser: User = {
+      ...defaultUser,
+      isLastPlanRequested: false,
+    };
+
+    // Act
+    render(
+      <IntlProviderDouble>
+        <UserPlan user={tooltipPlanUser} />
+      </IntlProviderDouble>
     );
 
-    expect(requestSentButton).toBeInTheDocument();
-    expect(tooltip).toBeInTheDocument();
+    const updatePlanButton = screen.queryByText("header.send_request");
+    const tip = screen.queryByText("header.tooltip_last_plan");
+    expect(updatePlanButton).not.toBeInTheDocument();
+    expect(tip).not.toBeInTheDocument();
   });
 
   it("should display sms plan information when is enabled", () => {

--- a/src/components/UserPlan.test.tsx
+++ b/src/components/UserPlan.test.tsx
@@ -128,22 +128,27 @@ describe(UserPlan.name, () => {
     expect(screen.getByText(upgradeLabel)).toBeInTheDocument();
   });
 
-  it("should render Modal when Upgrade button is clicked", async () => {
+  it("should display upgrade form modal when Upgrade button is clicked", async () => {
     // Arrange
-    const upgradeLabel = "UPGRADE";
-    const modalTestId = "modal";
+    const modalTestId = "upgrade.plan.form.modal";
+    const freeUser = {
+      ...defaultUser,
+      plan: {
+        ...defaultUser.plan,
+        buttonText: "upgrade.plan.button",
+      },
+    };
 
     // Act
     render(
       <MenuIntlProvider>
-        <UserPlan user={defaultUser} />
+        <UserPlan user={freeUser} />
       </MenuIntlProvider>
     );
 
-    const upgradeButton = screen.getByText(upgradeLabel);
+    const upgradeButton = screen.getByText("upgrade.plan.button");
     await user.click(upgradeButton);
-    const modal = screen.getByTestId(modalTestId);
-    expect(modal).toBeInTheDocument();
+    screen.getByTestId(modalTestId);
   });
 
   it("should render an Upgrade link when plan has a button url and no pending free upgrade", () => {

--- a/src/components/UserPlan.tsx
+++ b/src/components/UserPlan.tsx
@@ -108,7 +108,11 @@ export const UserPlan = ({ user }: UserPlanProps) => {
           )}
         </UserPlanType>
       )}
-      <Modal isOpen={isModalOpen} handleClose={() => setIsModalOpen(false)}>
+      <Modal
+        isOpen={isModalOpen}
+        handleClose={() => setIsModalOpen(false)}
+        data-testid={"upgrade.plan.form.modal"}
+      >
         <UpgradePlanForm
           isSubscriber={isSubscribers}
           handleClose={() => setIsModalOpen(false)}

--- a/src/components/UserPlan.tsx
+++ b/src/components/UserPlan.tsx
@@ -31,35 +31,26 @@ export const UserPlan = ({ user }: UserPlanProps) => {
     setIsModalOpen(true);
   };
 
-  const renderPlanLink = () => {
-    if (buttonUrl && !pendingFreeUpgrade)
-      return (
-        <a className="user-plan" href={buttonUrl}>
-          {plan.buttonText}
-        </a>
-      );
-  };
-
   return (
     <div className="user-plan--container">
       {!hasClientManager && (
         <>
           <UserPlanType>
             {isSubscribers || isMonthlyByEmail ? (
-              <>
-                <MonthlyPlan>
-                  <strong>{planName}</strong> ({maxSubscribers}{" "}
-                  {itemDescription})
-                </MonthlyPlan>
-                {renderPlanLink()}
-              </>
+              <UpdateItemDefault
+                showPlanLink={!!buttonUrl && !pendingFreeUpgrade}
+                buttonUrl={plan.buttonUrl}
+                buttonText={plan.buttonText}
+              >
+                <strong>{planName}</strong> ({maxSubscribers}{" "}
+                {itemDescription})
+              </UpdateItemDefault>
             ) : (
-              <>
-                <MonthlyPlan>
-                  <FormattedMessage id="header.plan_prepaid" />
-                </MonthlyPlan>
-                {renderPlanLink()}
-              </>
+              <UpdateItemDefault
+                showPlanLink={!!buttonUrl && !pendingFreeUpgrade}
+                buttonUrl={plan.buttonUrl}
+                buttonText={plan.buttonText}
+              />
             )}
             {!buttonUrl || pendingFreeUpgrade ? (
               <UpdatePlanButton
@@ -236,5 +227,29 @@ const UpdatePlanButton = (props: UpdatePlanButtonProp) => {
     <button onClick={props.click} className="user-plan">
       {props.text}
     </button>
+  );
+};
+
+const UpdateItemDefault = ({
+  showPlanLink,
+  buttonText,
+  buttonUrl,children
+}: {
+  showPlanLink: boolean;
+  buttonUrl: string;
+  buttonText: string;
+  children?: any;
+}) => {
+  return (
+    <>
+      <p className="user-plan--monthly-text">
+        {children ? children :<FormattedMessage id="header.plan_prepaid" />}
+      </p>
+      {showPlanLink ? (
+        <a className="user-plan" href={buttonUrl}>
+          {buttonText}
+        </a>
+      ) : null}
+    </>
   );
 };

--- a/src/components/UserPlan.tsx
+++ b/src/components/UserPlan.tsx
@@ -19,7 +19,6 @@ export const UserPlan = ({ user }: UserPlanProps) => {
     planType,
     itemDescription,
     buttonUrl,
-    buttonText,
     pendingFreeUpgrade,
     remainingCredits,
     description,
@@ -32,34 +31,11 @@ export const UserPlan = ({ user }: UserPlanProps) => {
     setIsModalOpen(true);
   };
 
-  const renderModalButton = () => (
-    <OpenModalButton className="user-plan" openModalHandler={openModalHandler}>
-      {buttonText}
-    </OpenModalButton>
-  );
-
-  const renderModalButtonWithTooltip = () => (
-    <div className="dp-request-sent">
-      <Tooltip>
-        <OpenModalButton
-          className="user-plan close-user--menu dp-tooltip-left"
-          openModalHandler={openModalHandler}
-        >
-          <FormattedMessage id="header.send_request" />
-          <div className="tooltiptext">
-            <FormattedMessage id="header.tooltip_last_plan" />
-          </div>
-        </OpenModalButton>
-        <span className="ms-icon icon-info-icon" />
-      </Tooltip>
-    </div>
-  );
-
   const renderPlanLink = () => {
     if (buttonUrl && !pendingFreeUpgrade)
       return (
         <a className="user-plan" href={buttonUrl}>
-          {buttonText}
+          {plan.buttonText}
         </a>
       );
   };
@@ -85,11 +61,13 @@ export const UserPlan = ({ user }: UserPlanProps) => {
                 {renderPlanLink()}
               </>
             )}
-            {!buttonUrl || pendingFreeUpgrade
-              ? !isLastPlanRequested
-                ? renderModalButton()
-                : renderModalButtonWithTooltip()
-              : ""}
+            {!buttonUrl || pendingFreeUpgrade ? (
+              <UpdatePlanButton
+                showTips={isLastPlanRequested}
+                click={openModalHandler}
+                text={plan.buttonText}
+              />
+            ) : null}
           </UserPlanType>
           <UserPlanType>
             <UserPlanInformation
@@ -220,16 +198,39 @@ const SmsInformation = ({
   );
 };
 
-const OpenModalButton = ({
-  className,
-  openModalHandler,
-  children,
-}: {
-  className: string;
-  openModalHandler: () => void;
-  children: React.ReactNode;
-}) => (
-  <button onClick={() => openModalHandler()} className={className}>
-    {children}
-  </button>
-);
+type UpdatePlanButtonProp =
+  | {
+      showTips: false;
+      text: string;
+      click: () => void;
+    }
+  | {
+      showTips: true;
+      click: () => void;
+    };
+
+const UpdatePlanButton = (props: UpdatePlanButtonProp) => {
+  if (props.showTips) {
+    return (
+      <div className="dp-request-sent">
+        <Tooltip>
+          <button
+            onClick={props.click}
+            className="user-plan close-user--menu dp-tooltip-left"
+          >
+            <FormattedMessage id="header.send_request" />
+            <div className="tooltiptext">
+              <FormattedMessage id="header.tooltip_last_plan" />
+            </div>
+          </button>
+          <span className="ms-icon icon-info-icon" />
+        </Tooltip>
+      </div>
+    );
+  }
+  return (
+    <button onClick={props.click} className="user-plan">
+      {props.text}
+    </button>
+  );
+};

--- a/src/components/UserPlan.tsx
+++ b/src/components/UserPlan.tsx
@@ -34,15 +34,15 @@ export const UserPlan = ({ user }: UserPlanProps) => {
     <div className="user-plan--container">
       <div className="user-plan--type">
         {isSubscribers || isMonthlyByEmail ? (
-          <UpdateItemDefault
+          <UpgradePlanItem
             showPlanLink={!!buttonUrl && !pendingFreeUpgrade}
             buttonUrl={plan.buttonUrl}
             buttonText={plan.buttonText}
           >
             <strong>{planName}</strong> ({maxSubscribers} {itemDescription})
-          </UpdateItemDefault>
+          </UpgradePlanItem>
         ) : (
-          <UpdateItemDefault
+          <UpgradePlanItem
             showPlanLink={!!buttonUrl && !pendingFreeUpgrade}
             buttonUrl={plan.buttonUrl}
             buttonText={plan.buttonText}
@@ -57,14 +57,14 @@ export const UserPlan = ({ user }: UserPlanProps) => {
         ) : null}
       </div>
       <div className="user-plan--type">
-        <UserPlanInformation
+        <CurrentPlanCredits
           planType={planType}
           remainingCredits={remainingCredits}
           credits={maxSubscribers}
           description={description}
         />
         {sms.smsEnabled ? (
-          <SmsInformation
+          <RechargeSMSPlanCredits
             buttonText={sms.buttonText}
             buttonUrl={sms.buttonUrl}
             description={sms.description}
@@ -88,7 +88,7 @@ export const UserPlan = ({ user }: UserPlanProps) => {
   );
 };
 
-const UserPlanInformation = ({
+const CurrentPlanCredits = ({
   planType,
   credits,
   remainingCredits,
@@ -123,7 +123,7 @@ const UserPlanInformation = ({
   );
 };
 
-const SmsInformation = ({
+const RechargeSMSPlanCredits = ({
   remainingCredits,
   description,
   buttonUrl,
@@ -196,7 +196,7 @@ const UpdatePlanButton = (props: UpdatePlanButtonProp) => {
   );
 };
 
-const UpdateItemDefault = ({
+const UpgradePlanItem = ({
   showPlanLink,
   buttonText,
   buttonUrl,

--- a/src/components/UserPlan.tsx
+++ b/src/components/UserPlan.tsx
@@ -10,8 +10,7 @@ interface UserPlanProps {
 }
 
 export const UserPlan = ({ user }: UserPlanProps) => {
-  const { sms, plan, hasClientManager, isLastPlanRequested, clientManager } =
-    user;
+  const { sms, plan, isLastPlanRequested } = user;
 
   const {
     planName,
@@ -33,72 +32,47 @@ export const UserPlan = ({ user }: UserPlanProps) => {
 
   return (
     <div className="user-plan--container">
-      {!hasClientManager && (
-        <>
-          <UserPlanType>
-            {isSubscribers || isMonthlyByEmail ? (
-              <UpdateItemDefault
-                showPlanLink={!!buttonUrl && !pendingFreeUpgrade}
-                buttonUrl={plan.buttonUrl}
-                buttonText={plan.buttonText}
-              >
-                <strong>{planName}</strong> ({maxSubscribers}{" "}
-                {itemDescription})
-              </UpdateItemDefault>
-            ) : (
-              <UpdateItemDefault
-                showPlanLink={!!buttonUrl && !pendingFreeUpgrade}
-                buttonUrl={plan.buttonUrl}
-                buttonText={plan.buttonText}
-              />
-            )}
-            {!buttonUrl || pendingFreeUpgrade ? (
-              <UpdatePlanButton
-                showTips={isLastPlanRequested}
-                click={openModalHandler}
-                text={plan.buttonText}
-              />
-            ) : null}
-          </UserPlanType>
-          <UserPlanType>
-            <UserPlanInformation
-              planType={planType}
-              remainingCredits={remainingCredits}
-              credits={maxSubscribers}
-              description={description}
-            />
-            {sms.smsEnabled ? (
-              <SmsInformation
-                buttonText={sms.buttonText}
-                buttonUrl={sms.buttonUrl}
-                description={sms.description}
-                remainingCredits={sms.remainingCredits}
-              />
-            ) : null}
-          </UserPlanType>
-        </>
-      )}
+      <div className="user-plan--type">
+        {isSubscribers || isMonthlyByEmail ? (
+          <UpdateItemDefault
+            showPlanLink={!!buttonUrl && !pendingFreeUpgrade}
+            buttonUrl={plan.buttonUrl}
+            buttonText={plan.buttonText}
+          >
+            <strong>{planName}</strong> ({maxSubscribers} {itemDescription})
+          </UpdateItemDefault>
+        ) : (
+          <UpdateItemDefault
+            showPlanLink={!!buttonUrl && !pendingFreeUpgrade}
+            buttonUrl={plan.buttonUrl}
+            buttonText={plan.buttonText}
+          />
+        )}
+        {!buttonUrl || pendingFreeUpgrade ? (
+          <UpdatePlanButton
+            showTips={isLastPlanRequested}
+            click={openModalHandler}
+            text={plan.buttonText}
+          />
+        ) : null}
+      </div>
+      <div className="user-plan--type">
+        <UserPlanInformation
+          planType={planType}
+          remainingCredits={remainingCredits}
+          credits={maxSubscribers}
+          description={description}
+        />
+        {sms.smsEnabled ? (
+          <SmsInformation
+            buttonText={sms.buttonText}
+            buttonUrl={sms.buttonUrl}
+            description={sms.description}
+            remainingCredits={sms.remainingCredits}
+          />
+        ) : null}
+      </div>
 
-      {hasClientManager && (
-        <UserPlanType>
-          {clientManager?.profileName && (
-            <MonthlyPlan>
-              <FormattedMessage id="header.profile" />{" "}
-              <strong>{clientManager?.profileName}</strong>
-            </MonthlyPlan>
-          )}
-          {!clientManager?.profileName && (
-            <>
-              <MonthlyPlan>
-                <FormattedMessage id="header.send_mails" />
-              </MonthlyPlan>
-              <p className="user-plan-enabled">
-                <FormattedMessage id="header.enabled" />
-              </p>
-            </>
-          )}
-        </UserPlanType>
-      )}
       <Modal
         isOpen={isModalOpen}
         handleClose={() => setIsModalOpen(false)}
@@ -113,14 +87,6 @@ export const UserPlan = ({ user }: UserPlanProps) => {
     </div>
   );
 };
-
-const MonthlyPlan = ({ children }: { children: React.ReactNode }) => {
-  return <p className="user-plan--monthly-text">{children}</p>;
-};
-
-const UserPlanType = ({ children }: { children: React.ReactNode }) => (
-  <div className="user-plan--type">{children}</div>
-);
 
 const UserPlanInformation = ({
   planType,
@@ -233,7 +199,8 @@ const UpdatePlanButton = (props: UpdatePlanButtonProp) => {
 const UpdateItemDefault = ({
   showPlanLink,
   buttonText,
-  buttonUrl,children
+  buttonUrl,
+  children,
 }: {
   showPlanLink: boolean;
   buttonUrl: string;
@@ -243,7 +210,7 @@ const UpdateItemDefault = ({
   return (
     <>
       <p className="user-plan--monthly-text">
-        {children ? children :<FormattedMessage id="header.plan_prepaid" />}
+        {children ? children : <FormattedMessage id="header.plan_prepaid" />}
       </p>
       {showPlanLink ? (
         <a className="user-plan" href={buttonUrl}>


### PR DESCRIPTION
Se realizó una refactorización general del componente UserPlan para tener lógica mas pequeña.
* Se separo el componente `<UserPlan/>` cuando el usuario tiene _**ClientManager**_ activo.
* Se permite definir un id de prueba en cada implementación del componente `<Modal/>`
* Se reescribió el botón de actualización de plan como un componente para mas semántica.