### PR TITLE
Actualización de pruebas frágiles

### DIFF
--- a/src/components/ValidateSubscriber/ValidateSubscribers.test.tsx
+++ b/src/components/ValidateSubscriber/ValidateSubscribers.test.tsx
@@ -124,9 +124,11 @@ describe("ValidateSubscribersComponent", () => {
     // Act
     render(
       <QueryClientProvider client={queryClient}>
-        <IntlProviderDouble>
-          <ValidateSubscribersForm onClose={jest.fn} />
-        </IntlProviderDouble>
+        <AppConfigurationProvider configuration={{ useDummies: true }}>
+          <IntlProviderDouble>
+            <ValidateSubscribersForm onClose={jest.fn} />
+          </IntlProviderDouble>
+        </AppConfigurationProvider>
       </QueryClientProvider>
     );
 


### PR DESCRIPTION
Las pruebas del componente `ValidateSubscribersForm` se rompían porque intentaba usar el contexto de la configuración (**_`appConfigurationProvider`_**), como solución se usa la configuración _dummy_.

Log de error: http://docker.fromdoppler.com:8080/blue/organizations/jenkins/FromDoppler%2Fdoppler-menu-mfe/detail/PR-174/2/pipeline/