### PR TITLE
[DE-726] corrección de error al mostrar formulario validación de subscriptores 

### DIFF
--- a/src/client/dopplerLegacyClient.ts
+++ b/src/client/dopplerLegacyClient.ts
@@ -3,8 +3,9 @@ import { DopplerLegacyClientImpl } from "./DopplerLegacyClientImpl";
 import { DopplerLegacyClientDummy } from "./DopplerLegacyClientDummy";
 import { MaxSubscribersData } from "../components/ValidateSubscriber/types";
 import { useAppConfiguration } from "../AppConfiguration";
+import { useMutation, useQuery } from "react-query";
 
-export const useDopplerLegacyClient = () => {
+const useDopplerLegacyClient = () => {
   const appConfiguration = useAppConfiguration();
   const dopplerLegacyClient: DopplerLegacyClient = appConfiguration.useDummies
     ? new DopplerLegacyClientDummy()
@@ -15,6 +16,33 @@ export const useDopplerLegacyClient = () => {
         })
       );
   return dopplerLegacyClient;
+};
+
+export const useSendMaxSubscribersData = () => {
+  const client = useDopplerLegacyClient();
+
+  return useMutation(
+    async (maxSubscribersData: MaxSubscribersData): Promise<boolean> => {
+      return await client.sendMaxSubscribersData(maxSubscribersData);
+    }
+  );
+};
+
+export const useGetMaxSubscribers = () => {
+  const client = useDopplerLegacyClient();
+
+  const queryFn = async () => await client.getMaxSubscribersData();
+  const queryOptions = {
+    refetchOnWindowFocus: false,
+    refetchOnReconnect: false,
+    retry: false,
+  };
+
+  return useQuery<MaxSubscribersData>(
+    "getMaxSubscribersData",
+    queryFn,
+    queryOptions
+  );
 };
 
 export interface DopplerLegacyClient {

--- a/src/components/HeaderMessages.test.tsx
+++ b/src/components/HeaderMessages.test.tsx
@@ -2,9 +2,10 @@ import { render, screen } from "@testing-library/react";
 import { HeaderMessages } from "./HeaderMessages";
 import { MenuIntlProvider } from "./i18n/MenuIntlProvider";
 import { Alert, User } from "../model";
-import { QueryClient, QueryClientProvider } from "react-query";
+import { QueryClient, QueryClientProvider, useQuery } from "react-query";
 import userEvent from "@testing-library/user-event";
 import * as dopplerLegacyClient from "../client/dopplerLegacyClient";
+import { MaxSubscribersData } from "./ValidateSubscriber/types";
 
 const userData: User = {
   email: "email@mock.com",
@@ -162,12 +163,18 @@ describe("<HeaderMessages />", () => {
       urlHelp: "https://help.fromdoppler.com/",
     };
     jest
-      .spyOn(dopplerLegacyClient, "useDopplerLegacyClient")
-      .mockImplementation(() => ({
-        getMaxSubscribersData: jest.fn(async () => questions),
-        sendAcceptButtonAction: jest.fn(),
-        sendMaxSubscribersData: jest.fn(async () => true),
-      }));
+      .spyOn(dopplerLegacyClient, "useGetMaxSubscribers")
+      .mockImplementation(() =>
+        useQuery<MaxSubscribersData>(
+          "getMaxSubscribersData",
+          async () => Promise.resolve(questions),
+          {
+            refetchOnWindowFocus: false,
+            refetchOnReconnect: false,
+            retry: false,
+          }
+        )
+      );
 
     const alertData: Alert = {
       type: "warning",

--- a/src/components/ValidateSubscriber/QuestionsForm.tsx
+++ b/src/components/ValidateSubscriber/QuestionsForm.tsx
@@ -8,7 +8,7 @@ import { Loading } from "../Loading";
 
 export interface QuestionsFormProps {
   questions: QuestionModel[];
-  onSubmit: () => Promise<boolean>;
+  onSubmit: () => void;
   customSubmit?: ReactNode;
   className?: string;
 }
@@ -38,7 +38,7 @@ export const QuestionsForm = ({
 
   const answers: any = normalizeQuestions(questions);
 
-  const handlerSubmit = async (values: any, { setSubmitting }: any) => {
+  const handlerSubmit = async (values: any) => {
     questions.forEach((questionItem, index) => {
       if (isCheckbox(questionItem.answer)) {
         questionItem.answer.value = values[`answer${index}`].join("-");
@@ -47,10 +47,7 @@ export const QuestionsForm = ({
         questionItem.answer.value = values[`answer${index}`];
       }
     });
-    const result = await onSubmit();
-    if (!result) {
-      setSubmitting(false);
-    }
+    await onSubmit();
   };
 
   const validate = (values: any) => {

--- a/src/components/ValidateSubscriber/ValidateSubscribers.test.tsx
+++ b/src/components/ValidateSubscriber/ValidateSubscribers.test.tsx
@@ -10,7 +10,7 @@ import * as dopplerLegacyClient from "../../client/dopplerLegacyClient";
 import userEvent from "@testing-library/user-event";
 import { AnswerType, MaxSubscribersData } from "./types";
 import { AppConfigurationProvider } from "../../AppConfiguration";
-import { QueryClient, QueryClientProvider } from "react-query";
+import { QueryClient, QueryClientProvider, useQuery } from "react-query";
 
 export const maxSubscribersData: MaxSubscribersData = {
   questionsList: [
@@ -111,14 +111,20 @@ describe("ValidateSubscribersComponent", () => {
   it("should render UnexpectedError when has an error", async () => {
     // Arrange
     jest
-      .spyOn(dopplerLegacyClient, "useDopplerLegacyClient")
-      .mockImplementationOnce(() => ({
-        getMaxSubscribersData: jest.fn(async () => {
-          throw new Error("Empty Doppler response");
-        }),
-        sendAcceptButtonAction: jest.fn(),
-        sendMaxSubscribersData: jest.fn(),
-      }));
+      .spyOn(dopplerLegacyClient, "useGetMaxSubscribers")
+      .mockImplementationOnce(() =>
+        useQuery<MaxSubscribersData>(
+          "getMaxSubscribersData",
+          async () => {
+            throw new Error("Empty Doppler response");
+          },
+          {
+            refetchOnWindowFocus: false,
+            refetchOnReconnect: false,
+            retry: false,
+          }
+        )
+      );
 
     const queryClient = new QueryClient();
     // Act
@@ -131,7 +137,7 @@ describe("ValidateSubscribersComponent", () => {
         </AppConfigurationProvider>
       </QueryClientProvider>
     );
-
+    screen.debug();
     // Assert
     const loader = screen.getByTestId("loading-box");
     await waitForElementToBeRemoved(loader);
@@ -140,12 +146,18 @@ describe("ValidateSubscribersComponent", () => {
 
   it("should render ValidateMaxSubscribersForm when there is form data", async () => {
     jest
-      .spyOn(dopplerLegacyClient, "useDopplerLegacyClient")
-      .mockImplementation(() => ({
-        getMaxSubscribersData: jest.fn(async () => maxSubscribersData),
-        sendAcceptButtonAction: jest.fn(),
-        sendMaxSubscribersData: jest.fn(async () => true),
-      }));
+      .spyOn(dopplerLegacyClient, "useGetMaxSubscribers")
+      .mockImplementation(() =>
+        useQuery<MaxSubscribersData>(
+          "getMaxSubscribersData",
+          async () => Promise.resolve(maxSubscribersData),
+          {
+            refetchOnWindowFocus: false,
+            refetchOnReconnect: false,
+            retry: false,
+          }
+        )
+      );
 
     const queryClient = new QueryClient();
     // Act
@@ -184,12 +196,18 @@ describe("ValidateSubscribersComponent", () => {
     };
 
     jest
-      .spyOn(dopplerLegacyClient, "useDopplerLegacyClient")
-      .mockImplementation(() => ({
-        getMaxSubscribersData: jest.fn(async () => formData),
-        sendAcceptButtonAction: jest.fn(),
-        sendMaxSubscribersData: jest.fn(async () => true),
-      }));
+      .spyOn(dopplerLegacyClient, "useGetMaxSubscribers")
+      .mockImplementation(() =>
+        useQuery<MaxSubscribersData>(
+          "getMaxSubscribersData",
+          async () => Promise.resolve(formData),
+          {
+            refetchOnWindowFocus: false,
+            refetchOnReconnect: false,
+            retry: false,
+          }
+        )
+      );
 
     const queryClient = new QueryClient();
     // Act


### PR DESCRIPTION
Antes cuando se intentaba abrir el formulario validación de subscriptores desde la alerta mostraba un error inesperado ([Hilo](https://makingsense.slack.com/archives/CRXR62TC2/p1663342220796679)).

Para solucionar el error se reorganizó el uso de _React-query_ en hooks para mantener el scope adecuadamente.