### PR TITLE
[DE-803] corregir bandeja de notificaciones cuando se tienen mas de una

### DIFF
--- a/src/components/MenuRight.tsx
+++ b/src/components/MenuRight.tsx
@@ -19,12 +19,10 @@ export const MenuRight = ({
   return (
     <nav className="nav-right-main" aria-label="secondary nav">
       <ul className="nav-right-main--list">
-        <li>
-          <Notifications
-            notifications={notifications}
-            emptyNotificationText={emptyNotificationText}
-          />
-        </li>
+        <Notifications
+          notifications={notifications}
+          emptyNotificationText={emptyNotificationText}
+        />
         <li>
           <a href="https://help.fromdoppler.com/en">
             <span className="ms-icon icon-header-help"></span>

--- a/src/components/Notifications.tsx
+++ b/src/components/Notifications.tsx
@@ -20,7 +20,7 @@ export const Notifications = ({
     };
 
     return ({ children }: any) => (
-      <div ref={notificationsRef}>
+      <li ref={notificationsRef}>
         <span
           className="user-menu--open active"
           data-count={count ? count : null}
@@ -29,7 +29,7 @@ export const Notifications = ({
           <span className="ms-icon icon-notification" />
         </span>
         {children}
-      </div>
+      </li>
     );
   }, [count, notificationsRef]);
 
@@ -39,20 +39,19 @@ export const Notifications = ({
 
   return (
     <NotificationWrapper>
-      {notifications.map((notification, index) => {
-        return (
-          <div
-            key={index}
-            className={`user-menu helper--right dp-notifications ${
-              openNotification ? "open" : ""
-            }`}
-          >
-            <div className="dp-msj-notif">
+      <div
+        className={`user-menu helper--right dp-notifications ${
+          openNotification ? "open" : ""
+        }`}
+      >
+        {notifications.map((notification, index) => {
+          return (
+            <div key={index} className="dp-msj-notif">
               <div dangerouslySetInnerHTML={{ __html: notification }} />
             </div>
-          </div>
-        );
-      })}
+          );
+        })}
+      </div>
     </NotificationWrapper>
   );
 };


### PR DESCRIPTION
Se reorganizaron los componentes de la bandeja de notificaciones siguiendo los lineamientos del [StyleGuide](https://cdn.fromdoppler.com/doppler-style-guide/documentation/int/header-component.html).

https://user-images.githubusercontent.com/6733401/193164425-c46a088d-04e4-4f5b-a766-f3ff91e3956a.mp4

