### PR TITLE
[DE-809] envió de confirmación al back desde la confirmación en mensaje de alerta

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -8,6 +8,7 @@ import {
 import testUserData from "./testUserData.json";
 import { MenuIntlProvider } from "./components/i18n/MenuIntlProvider";
 import { safeUserData } from "./utils";
+import { QueryClient, QueryClientProvider } from "react-query";
 
 test("renders Doppler Menu Micro-Frontend", () => {
   const mainHeaderLabel = "main header";
@@ -27,11 +28,14 @@ test("renders Doppler Menu Micro-Frontend", () => {
     onSessionUpdate: () => {},
     start: () => {},
   };
+  const queryClient = new QueryClient();
 
   render(
     <AppSessionStateProvider appSessionStateClient={dummyAppSessionStateClient}>
       <MenuIntlProvider>
-        <App />
+        <QueryClientProvider client={queryClient}>
+          <App />
+        </QueryClientProvider>
       </MenuIntlProvider>
     </AppSessionStateProvider>
   );

--- a/src/client/dopplerLegacyClient.ts
+++ b/src/client/dopplerLegacyClient.ts
@@ -28,6 +28,13 @@ export const useSendMaxSubscribersData = () => {
   );
 };
 
+export const useSendAcceptButtonAction = () => {
+  const client = useDopplerLegacyClient();
+  return useMutation(
+    async (): Promise<boolean> => await client.sendAcceptButtonAction()
+  );
+};
+
 export const useGetMaxSubscribers = () => {
   const client = useDopplerLegacyClient();
 

--- a/src/components/HeaderMessages.test.tsx
+++ b/src/components/HeaderMessages.test.tsx
@@ -45,9 +45,12 @@ describe("<HeaderMessages />", () => {
       button: { url, text: "upgrade.now" },
     };
 
+    const queryClient = new QueryClient();
     render(
       <MenuIntlProvider>
-        <HeaderMessages alert={alertData} user={userData} />
+        <QueryClientProvider client={queryClient}>
+          <HeaderMessages alert={alertData} user={userData} />
+        </QueryClientProvider>
       </MenuIntlProvider>
     );
 
@@ -67,9 +70,12 @@ describe("<HeaderMessages />", () => {
         button: { text: "upgrade.now.button", action },
       };
 
+      const queryClient = new QueryClient();
       render(
         <MenuIntlProvider>
-          <HeaderMessages alert={alertData} user={userData} />
+          <QueryClientProvider client={queryClient}>
+            <HeaderMessages alert={alertData} user={userData} />
+          </QueryClientProvider>
         </MenuIntlProvider>
       );
 
@@ -116,9 +122,12 @@ describe("<HeaderMessages />", () => {
       },
     };
 
+    const queryClient = new QueryClient();
     render(
       <MenuIntlProvider>
-        <HeaderMessages alert={alertData} user={userData} />
+        <QueryClientProvider client={queryClient}>
+          <HeaderMessages alert={alertData} user={userData} />
+        </QueryClientProvider>
       </MenuIntlProvider>
     );
 
@@ -135,9 +144,12 @@ describe("<HeaderMessages />", () => {
       },
     };
 
+    const queryClient = new QueryClient();
     render(
       <MenuIntlProvider>
-        <HeaderMessages alert={alertData} user={userData} />
+        <QueryClientProvider client={queryClient}>
+          <HeaderMessages alert={alertData} user={userData} />
+        </QueryClientProvider>
       </MenuIntlProvider>
     );
 

--- a/src/components/HeaderMessages.tsx
+++ b/src/components/HeaderMessages.tsx
@@ -3,6 +3,7 @@ import { Modal } from "./Modal";
 import { User, Alert } from "../model";
 import { UpgradePlanForm } from "./UpgradePlanForm";
 import { ValidateSubscribersForm } from "./ValidateSubscriber/ValidateSubscribersForm";
+import { useSendAcceptButtonAction } from "../client/dopplerLegacyClient";
 
 interface HeaderMessagesProp {
   alert: Alert;
@@ -15,6 +16,7 @@ const validateSubscribersPopup = "validateSubscribersPopup";
 export const HeaderMessages = ({ alert, user }: HeaderMessagesProp) => {
   const [modalIsOpen, setModalIsOpen] = useState(false);
   const [currentAlert, setCurrentAlert] = useState<Alert>(alert);
+  const { mutate: sendAcceptButtonAction } = useSendAcceptButtonAction();
 
   if (!Object.keys(alert).length) {
     return null;
@@ -36,6 +38,15 @@ export const HeaderMessages = ({ alert, user }: HeaderMessagesProp) => {
 
   const showAction = button?.url || button?.action;
 
+  const setButtonOnclick = () => {
+    if (hasModal) {
+      return toggleModal(true);
+    }
+    if (alert.button?.action === "closeModal") {
+      return sendAcceptButtonAction();
+    }
+  };
+
   return (
     <>
       <div className={`messages-container sticky ${type}`}>
@@ -45,7 +56,7 @@ export const HeaderMessages = ({ alert, user }: HeaderMessagesProp) => {
             <ActionComponent
               type={button?.url ? "LINK" : "BUTTON"}
               url={button?.url}
-              onClick={() => toggleModal(true)}
+              onClick={() => setButtonOnclick()}
             >
               {button?.text}
             </ActionComponent>

--- a/src/components/ValidateSubscriber/ValidateSubscribers.test.tsx
+++ b/src/components/ValidateSubscriber/ValidateSubscribers.test.tsx
@@ -139,7 +139,7 @@ describe("ValidateSubscribersComponent", () => {
         </AppConfigurationProvider>
       </QueryClientProvider>
     );
-    screen.debug();
+
     // Assert
     const loader = screen.getByTestId("loading-box");
     await waitForElementToBeRemoved(loader);


### PR DESCRIPTION
Se replica la lógica de [Webapp ](https://github.com/FromDoppler/doppler-webapp/blob/409f3818aeb4eab76db317de11bbc017393d7af5/src/components/Header/HeaderMessages/HeaderMessages.js#L26-L33)para la confirmación de la alerta de máximo de subscriptores

![image](https://user-images.githubusercontent.com/6733401/193501038-6a17b6ac-133d-499c-a850-98c72dda533d.png)

Al recargar la alerta desaparece.

https://user-images.githubusercontent.com/6733401/193501104-b4c897e2-ad68-434a-aca1-21a581e7df2c.mp4