### PR TITLE
DE-806 - Read forced or default menu item on Menu MFE initialization

### DIFF
--- a/src/components/Header.test.tsx
+++ b/src/components/Header.test.tsx
@@ -45,6 +45,8 @@ describe(Header.name, () => {
           navBar={{
             currentUrl: "/",
             selectedItemId: null,
+            defaultActiveItemId: null,
+            forcedActiveItemId: null,
             items: [],
             isExpanded: false,
           }}

--- a/src/components/Nav.test.tsx
+++ b/src/components/Nav.test.tsx
@@ -58,6 +58,8 @@ describe(Nav.name, () => {
         navBar={{
           currentUrl: "/",
           selectedItemId: null,
+          defaultActiveItemId: null,
+          forcedActiveItemId: null,
           items: [],
           isExpanded: false,
         }}
@@ -76,6 +78,8 @@ describe(Nav.name, () => {
         navBar={{
           currentUrl: "/",
           selectedItemId: null,
+          defaultActiveItemId: null,
+          forcedActiveItemId: null,
           items: nav,
           isExpanded: false,
         }}

--- a/src/hooks/useMeta.test.tsx
+++ b/src/hooks/useMeta.test.tsx
@@ -1,0 +1,49 @@
+import { render, screen } from "@testing-library/react";
+import { useMeta } from "./useMeta";
+
+describe(useMeta.name, () => {
+  it("should return selected meta content value", () => {
+    const metaName = "metaName123";
+    const expectedSelector = `meta[name="${metaName}"]`;
+    const metaContent = "content123";
+    const metaElement = { content: metaContent } as HTMLMetaElement;
+
+    const querySelectorDouble = (selectors: string) =>
+      selectors == expectedSelector ? metaElement : null;
+
+    const { TestComponent, windowDouble } = createTestContext();
+    windowDouble.document = {
+      querySelector: querySelectorDouble,
+    };
+
+    render(<TestComponent metaName={metaName} />);
+
+    screen.getByText(`[${metaContent}]`);
+  });
+
+  it("should return null when meta element is not found", () => {
+    const metaName = "metaName123";
+
+    const querySelectorDouble = () => null;
+
+    const { TestComponent, windowDouble } = createTestContext();
+    windowDouble.document = {
+      querySelector: querySelectorDouble,
+    };
+
+    render(<TestComponent metaName={metaName} />);
+
+    screen.getByText(`[]`);
+  });
+});
+
+function createTestContext() {
+  const windowDouble: any = {};
+
+  const TestComponent = ({ metaName }: { metaName: string }) => {
+    const content = useMeta(metaName, windowDouble as any);
+    return <>[{content}]</>;
+  };
+
+  return { TestComponent, windowDouble };
+}

--- a/src/hooks/useMeta.tsx
+++ b/src/hooks/useMeta.tsx
@@ -1,0 +1,12 @@
+import { useState } from "react";
+
+export function useMeta(name: string, global: Window = window) {
+  // TODO: listening DOM changes and update the value
+  // https://makingsense.atlassian.net/browse/DE-810
+  const [content] = useState(
+    () =>
+      global.document.querySelector<HTMLMetaElement>(`meta[name="${name}"]`)
+        ?.content || null
+  );
+  return content;
+}

--- a/src/navbar-state/navbar-state-abstractions.ts
+++ b/src/navbar-state/navbar-state-abstractions.ts
@@ -27,6 +27,8 @@ export type NavBarState = Readonly<{
   /** selectedItemId is based on mouse hover.
    * It should be the idHTML of the last primaryNavItem that has been hovered */
   selectedItemId: string | null;
+  defaultActiveItemId: string | null;
+  forcedActiveItemId: string | null;
   items: ReadonlyArray<PrimaryNavItemState>;
   /** isExpanded is based on mouse hover.
    * It should be true when mouse is hovering over a primaryNavItem,
@@ -39,4 +41,6 @@ export type NavBarState = Readonly<{
 export type NavBarStateReducerAction =
   | { type: "items/updated"; items: ReadonlyArray<PrimaryNavItemState> }
   | { type: "url/updated"; href: string }
-  | { type: "selected-item/updated"; idHTML: string | null };
+  | { type: "selected-item/updated"; idHTML: string | null }
+  | { type: "default-active/updated"; idHTML: string | null }
+  | { type: "forced-active/updated"; idHTML: string | null };

--- a/src/navbar-state/navbar-state-hook.ts
+++ b/src/navbar-state/navbar-state-hook.ts
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { AppSessionState } from "../session/app-session-abstractions";
 import { useNavBarStateReducer } from "./navbar-state-reducer";
 import {
@@ -41,10 +41,30 @@ export function useNavBarState({
   /** call this on mouse leave menu */
   unselectNavItem: () => void;
 } {
+  // TODO: read them from DOM using a custom hook to allow to scale to listening DOM
+  const [defaultActiveItemId] = useState(null);
+  const [forcedActiveItemId] = useState(null);
+
   const [state, dispatch] = useNavBarStateReducer(() => ({
     currentUrl,
+    defaultActiveItemId,
+    forcedActiveItemId,
     items: extractNavItems(appSessionState),
   }));
+
+  useEffect(() => {
+    dispatch({
+      type: "default-active/updated",
+      idHTML: defaultActiveItemId,
+    });
+  }, [defaultActiveItemId, dispatch]);
+
+  useEffect(() => {
+    dispatch({
+      type: "forced-active/updated",
+      idHTML: forcedActiveItemId,
+    });
+  }, [forcedActiveItemId, dispatch]);
 
   useEffect(() => {
     dispatch({

--- a/src/navbar-state/navbar-state-hook.ts
+++ b/src/navbar-state/navbar-state-hook.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
 import { AppSessionState } from "../session/app-session-abstractions";
 import { useNavBarStateReducer } from "./navbar-state-reducer";
 import {
@@ -6,6 +6,7 @@ import {
   PrimaryNavItemState,
   SecondaryNavItemState,
 } from "./navbar-state-abstractions";
+import { useMeta } from "../hooks/useMeta";
 
 function extractNavItems(
   appSessionState: AppSessionState
@@ -41,9 +42,8 @@ export function useNavBarState({
   /** call this on mouse leave menu */
   unselectNavItem: () => void;
 } {
-  // TODO: read them from DOM using a custom hook to allow to scale to listening DOM
-  const [defaultActiveItemId] = useState(null);
-  const [forcedActiveItemId] = useState(null);
+  const defaultActiveItemId = useMeta("doppler-menu-mfe:default-active-item");
+  const forcedActiveItemId = useMeta("doppler-menu-mfe:force-active-item");
 
   const [state, dispatch] = useNavBarStateReducer(() => ({
     currentUrl,

--- a/src/navbar-state/navbar-state-reducer.test.tsx
+++ b/src/navbar-state/navbar-state-reducer.test.tsx
@@ -54,6 +54,8 @@ describe(navBarStateReducer.name, () => {
         isExpanded: false,
         items: [],
         selectedItemId: null,
+        defaultActiveItemId: null,
+        forcedActiveItemId: null,
       } as const;
       const action = {
         type: "items/updated",
@@ -79,6 +81,8 @@ describe(navBarStateReducer.name, () => {
         isExpanded: false,
         items: [item0, item1, item2],
         selectedItemId: null,
+        defaultActiveItemId: null,
+        forcedActiveItemId: null,
       } as const;
       const action = {
         type: "url/updated",
@@ -102,6 +106,8 @@ describe(navBarStateReducer.name, () => {
         isExpanded: false,
         items: [{ ...item0, isActive: true }, item1, item2],
         selectedItemId: null,
+        defaultActiveItemId: null,
+        forcedActiveItemId: null,
       } as const;
       const action = {
         type: "url/updated",
@@ -151,6 +157,8 @@ describe(navBarStateReducer.name, () => {
           },
         ],
         selectedItemId: idHTML2,
+        defaultActiveItemId: null,
+        forcedActiveItemId: null,
       } as const;
       const action = {
         type: "url/updated",
@@ -196,6 +204,8 @@ describe(navBarStateReducer.name, () => {
           item2,
         ],
         selectedItemId: null,
+        defaultActiveItemId: null,
+        forcedActiveItemId: null,
       } as const;
       const action = {
         type: "url/updated",
@@ -240,6 +250,8 @@ describe(navBarStateReducer.name, () => {
           item2,
         ],
         selectedItemId: idHTML1,
+        defaultActiveItemId: null,
+        forcedActiveItemId: null,
       } as const;
       const action = {
         type: "selected-item/updated",
@@ -282,6 +294,8 @@ describe(navBarStateReducer.name, () => {
           },
         ],
         selectedItemId: null,
+        defaultActiveItemId: null,
+        forcedActiveItemId: null,
       } as const;
       const action = {
         type: "selected-item/updated",
@@ -325,6 +339,8 @@ describe(navBarStateReducer.name, () => {
           },
         ],
         selectedItemId: null,
+        defaultActiveItemId: null,
+        forcedActiveItemId: null,
       } as const;
       const action = {
         type: "selected-item/updated",
@@ -378,6 +394,8 @@ describe(navBarStateReducer.name, () => {
           },
         ],
         selectedItemId: null,
+        defaultActiveItemId: null,
+        forcedActiveItemId: null,
       } as const;
       const action = {
         type: "selected-item/updated",
@@ -433,6 +451,8 @@ describe(navBarStateReducer.name, () => {
           },
         ],
         selectedItemId: idHTML2,
+        defaultActiveItemId: null,
+        forcedActiveItemId: null,
       } as const;
       const action = {
         type: "selected-item/updated",
@@ -462,7 +482,12 @@ describe(useNavBarStateReducer.name, () => {
     it("should accept empty items", () => {
       // Arrange
       const currentUrl = url1;
-      const initializationData = { currentUrl, items: [] };
+      const initializationData = {
+        currentUrl,
+        defaultActiveItemId: null,
+        forcedActiveItemId: null,
+        items: [],
+      };
 
       const { TestComponent, getCurrentState } = createTestContext(
         () => initializationData
@@ -483,6 +508,8 @@ describe(useNavBarStateReducer.name, () => {
       // Arrange
       const initializationData = {
         currentUrl: url1,
+        defaultActiveItemId: null,
+        forcedActiveItemId: null,
         items: [item0, item1, item2],
       };
 
@@ -510,6 +537,8 @@ describe(useNavBarStateReducer.name, () => {
 function createTestContext(
   getInitializationData: () => {
     currentUrl: string;
+    defaultActiveItemId: string | null;
+    forcedActiveItemId: string | null;
     items: ReadonlyArray<PrimaryNavItemState>;
   }
 ): {

--- a/src/navbar-state/navbar-state-reducer.test.tsx
+++ b/src/navbar-state/navbar-state-reducer.test.tsx
@@ -99,6 +99,30 @@ describe(navBarStateReducer.name, () => {
       expect(state1.items[2]).toEqual(item2);
     });
 
+    it("should not override active item when there is a forced one", () => {
+      // Arrange
+      const state0 = {
+        currentUrl: "Unknown URL",
+        isExpanded: false,
+        items: [item0, item1, item2],
+        selectedItemId: null,
+        defaultActiveItemId: null,
+        forcedActiveItemId: idHTML2,
+      } as const;
+      const action = {
+        type: "url/updated",
+        href: url1,
+      } as const;
+
+      // Act
+      const state1 = navBarStateReducer(state0, action);
+
+      // Assert
+      expect(state1.currentUrl).toBe(url1);
+      expect(state1.items[1].isActive).toBe(false);
+      expect(state1.items[2].isActive).toBe(true);
+    });
+
     it("should change active item when there is a previously activated item", () => {
       // Arrange
       const state0 = {
@@ -217,6 +241,76 @@ describe(navBarStateReducer.name, () => {
 
       // Assert
       expect(state1.currentUrl).toBe("urlSubItem0");
+      expect(state1.isExpanded).toBe(true);
+      expect(state1.items).toHaveLength(3);
+      expect(state1.items[0].isActive).toBe(true);
+      expect(state1.items[0].isOpen).toBe(true);
+      expect(state1.items[0].subNavItems![0].isActive).toBe(true);
+      expect(state1.items[1]).toEqual(item1);
+      expect(state1.items[2]).toEqual(item2);
+    });
+  });
+
+  describe("forced-active/updated action", () => {
+    it("should set active item when there is not a previously activated item", () => {
+      // Arrange
+      const state0 = {
+        currentUrl: "Unknown URL",
+        isExpanded: false,
+        items: [item0, item1, item2],
+        selectedItemId: null,
+        defaultActiveItemId: null,
+        forcedActiveItemId: null,
+      } as const;
+      const action = {
+        type: "forced-active/updated",
+        idHTML: idHTML1,
+      } as const;
+
+      // Act
+      const state1 = navBarStateReducer(state0, action);
+
+      // Assert
+      expect(state1.currentUrl).toBe(state0.currentUrl);
+      expect(state1.items[1].isActive).toBe(true);
+      expect(state1.items[0]).toEqual(item0);
+      expect(state1.items[2]).toEqual(item2);
+    });
+
+    it("should open the navbar when the URL matches a subItem", () => {
+      // Arrange
+      const state0 = {
+        currentUrl: "Unknown URL",
+        isExpanded: false,
+        items: [
+          {
+            ...item0,
+            subNavItems: [
+              {
+                title: "subItem0",
+                url: "urlSubItem0",
+                idHTML: "idHTMLSubitem0",
+                isActive: false,
+              },
+            ],
+          },
+          item1,
+          item2,
+        ],
+        selectedItemId: null,
+        defaultActiveItemId: null,
+        forcedActiveItemId: null,
+      } as const;
+      const action = {
+        type: "forced-active/updated",
+        idHTML: "idHTMLSubitem0",
+      } as const;
+
+      // Act
+      const state1 = navBarStateReducer(state0, action);
+
+      // Assert
+      expect(state1.currentUrl).toBe(state0.currentUrl);
       expect(state1.isExpanded).toBe(true);
       expect(state1.items).toHaveLength(3);
       expect(state1.items[0].isActive).toBe(true);

--- a/src/navbar-state/navbar-state-reducer.test.tsx
+++ b/src/navbar-state/navbar-state-reducer.test.tsx
@@ -147,6 +147,31 @@ describe(navBarStateReducer.name, () => {
       expect(state1.items[1].isActive).toBe(true);
     });
 
+    it("should remove active item when URL is not found", () => {
+      // Arrange
+      const state0 = {
+        currentUrl: url0,
+        isExpanded: false,
+        items: [{ ...item0, isActive: true }, item1, item2],
+        selectedItemId: null,
+        defaultActiveItemId: null,
+        forcedActiveItemId: null,
+      } as const;
+      const action = {
+        type: "url/updated",
+        href: "UNKNOWN URL",
+      } as const;
+
+      // Act
+      const state1 = navBarStateReducer(state0, action);
+
+      // Assert
+      expect(state1.currentUrl).toBe("UNKNOWN URL");
+      expect(state1.items[0].isActive).toBe(false);
+      expect(state1.items[1].isActive).toBe(false);
+      expect(state1.items[2].isActive).toBe(false);
+    });
+
     it("should deselect item", () => {
       // Arrange
       const state0 = {

--- a/src/navbar-state/navbar-state-reducer.test.tsx
+++ b/src/navbar-state/navbar-state-reducer.test.tsx
@@ -172,6 +172,31 @@ describe(navBarStateReducer.name, () => {
       expect(state1.items[2].isActive).toBe(false);
     });
 
+    it("should active default item when URL is not found", () => {
+      // Arrange
+      const state0 = {
+        currentUrl: url0,
+        isExpanded: false,
+        items: [{ ...item0, isActive: true }, item1, item2],
+        selectedItemId: null,
+        defaultActiveItemId: idHTML2,
+        forcedActiveItemId: null,
+      } as const;
+      const action = {
+        type: "url/updated",
+        href: "UNKNOWN URL",
+      } as const;
+
+      // Act
+      const state1 = navBarStateReducer(state0, action);
+
+      // Assert
+      expect(state1.currentUrl).toBe("UNKNOWN URL");
+      expect(state1.items[0].isActive).toBe(false);
+      expect(state1.items[1].isActive).toBe(false);
+      expect(state1.items[2].isActive).toBe(true);
+    });
+
     it("should deselect item", () => {
       // Arrange
       const state0 = {
@@ -328,6 +353,76 @@ describe(navBarStateReducer.name, () => {
       } as const;
       const action = {
         type: "forced-active/updated",
+        idHTML: "idHTMLSubitem0",
+      } as const;
+
+      // Act
+      const state1 = navBarStateReducer(state0, action);
+
+      // Assert
+      expect(state1.currentUrl).toBe(state0.currentUrl);
+      expect(state1.isExpanded).toBe(true);
+      expect(state1.items).toHaveLength(3);
+      expect(state1.items[0].isActive).toBe(true);
+      expect(state1.items[0].isOpen).toBe(true);
+      expect(state1.items[0].subNavItems![0].isActive).toBe(true);
+      expect(state1.items[1]).toEqual(item1);
+      expect(state1.items[2]).toEqual(item2);
+    });
+  });
+
+  describe("default-active/updated action", () => {
+    it("should set active item when there is not a previously activated item", () => {
+      // Arrange
+      const state0 = {
+        currentUrl: "Unknown URL",
+        isExpanded: false,
+        items: [item0, item1, item2],
+        selectedItemId: null,
+        defaultActiveItemId: null,
+        forcedActiveItemId: null,
+      } as const;
+      const action = {
+        type: "default-active/updated",
+        idHTML: idHTML1,
+      } as const;
+
+      // Act
+      const state1 = navBarStateReducer(state0, action);
+
+      // Assert
+      expect(state1.currentUrl).toBe(state0.currentUrl);
+      expect(state1.items[1].isActive).toBe(true);
+      expect(state1.items[0]).toEqual(item0);
+      expect(state1.items[2]).toEqual(item2);
+    });
+
+    it("should open the navbar when the URL matches a subItem", () => {
+      // Arrange
+      const state0 = {
+        currentUrl: "Unknown URL",
+        isExpanded: false,
+        items: [
+          {
+            ...item0,
+            subNavItems: [
+              {
+                title: "subItem0",
+                url: "urlSubItem0",
+                idHTML: "idHTMLSubitem0",
+                isActive: false,
+              },
+            ],
+          },
+          item1,
+          item2,
+        ],
+        selectedItemId: null,
+        defaultActiveItemId: null,
+        forcedActiveItemId: null,
+      } as const;
+      const action = {
+        type: "default-active/updated",
         idHTML: "idHTMLSubitem0",
       } as const;
 

--- a/src/navbar-state/navbar-state-reducer.ts
+++ b/src/navbar-state/navbar-state-reducer.ts
@@ -104,10 +104,12 @@ function buildNavBarState({
 }): NavBarState {
   const { activePrimaryItem, activeSecondaryItem } = (forcedActiveItemId
     ? findActiveItemsByIdHTML(forcedActiveItemId, items)
-    : findActiveItemsByUrl(currentUrl, items)) || {
-    activePrimaryItem: null,
-    activeSecondaryItem: null,
-  };
+    : findActiveItemsByUrl(currentUrl, items)) ||
+    (defaultActiveItemId &&
+      findActiveItemsByIdHTML(defaultActiveItemId, items)) || {
+      activePrimaryItem: null,
+      activeSecondaryItem: null,
+    };
 
   const selectedPrimaryItem = findPrimaryItemByIdHTML({
     idHTML: selectedItemId,


### PR DESCRIPTION
It searchs for meta elements in DOM to override the URL-based active menu item.

Elements like `<meta name="doppler-menu-mfe:default-active-item" content="listMasterSubscriberMenu" />` would set the active menu item if the URL does not match an existing one.

![image](https://user-images.githubusercontent.com/1157864/193329096-036291d5-a4aa-4056-98b6-c2812618dc6f.png)

Elements like `<meta name="doppler-menu-mfe:force-active-item" content="listMasterSubscriberMenu" />` will set the active menu item whatever is the URL.

![image](https://user-images.githubusercontent.com/1157864/193329137-02218bfb-cc77-41d3-b5ae-bda1ef9b813b.png)
