### PR TITLE
[DE-818] Corregida campanita de notificaciones

### DIFF
--- a/src/components/Notifications.tsx
+++ b/src/components/Notifications.tsx
@@ -15,9 +15,7 @@ export const Notifications = ({
   const notificationsRef = useOnclickOutside(() => setOpenNotification(false));
 
   const NotificationWrapper = useMemo(() => {
-    const handleToggleNotification = () => {
-      setOpenNotification((prev) => !prev);
-    };
+    const handleToggleNotification = () => setOpenNotification((prev) => !prev);
 
     return ({ children }: any) => (
       <li ref={notificationsRef}>
@@ -31,7 +29,7 @@ export const Notifications = ({
         {children}
       </li>
     );
-  }, [count, notificationsRef]);
+  }, [count, notificationsRef, openNotification, setOpenNotification]);
 
   if (count < 1) {
     return <NotificationWrapper>{emptyNotificationText}</NotificationWrapper>;

--- a/src/components/Notifications.tsx
+++ b/src/components/Notifications.tsx
@@ -15,7 +15,8 @@ export const Notifications = ({
   const notificationsRef = useOnclickOutside(() => setOpenNotification(false));
 
   const NotificationWrapper = useMemo(() => {
-    const handleToggleNotification = () => setOpenNotification((prev) => !prev);
+    const handleToggleNotification = () =>
+      setOpenNotification(!openNotification);
 
     return ({ children }: any) => (
       <li ref={notificationsRef}>


### PR DESCRIPTION
Antes al hacer clic sobre la campanita de notificaciones no se mostraba la bandeja de notificaciones, ahora funciona desde el primer clic.

https://user-images.githubusercontent.com/6733401/193596390-68c16d31-d22e-4e6f-bf4a-dc3d4ad7a57f.mp4

