### PR TITLE
[DE-809] ocultar mensaje de alerta cuando se da click en boton entendido

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,7 +3,7 @@ import { HeaderMessages } from "./components/HeaderMessages";
 import { useLocationHref } from "./hooks/useLocationHref";
 import { useAppSessionState } from "./session/AppSessionStateContext";
 import { useNavBarState } from "./navbar-state/navbar-state-hook";
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 
 function App({
   onStatusUpdate,
@@ -18,6 +18,7 @@ function App({
     currentUrl: href,
     appSessionState,
   });
+  const [hideHeaderMessage, setHideHeaderMessage] = useState(false);
 
   useEffect(() => {
     onStatusUpdate?.(appSessionState.status);
@@ -29,12 +30,17 @@ function App({
 
   const { notifications, emptyNotificationText, user, alert } =
     appSessionState.userData;
+  const closeAlert = () => {
+    setHideHeaderMessage(true);
+  };
 
   return (
     <>
       {
         // TODO: confirm if it is rendered in the right way
-        alert ? <HeaderMessages alert={alert} user={user} /> : null
+        alert && !hideHeaderMessage ? (
+          <HeaderMessages alert={alert} user={user} onClose={closeAlert} />
+        ) : null
       }
       <Header
         selectNavItem={selectNavItem}
@@ -43,7 +49,7 @@ function App({
         notifications={notifications}
         emptyNotificationText={emptyNotificationText}
         user={user}
-        sticky={!!alert}
+        sticky={!!alert && !hideHeaderMessage}
       />
     </>
   );

--- a/src/client/dopplerLegacyClient.ts
+++ b/src/client/dopplerLegacyClient.ts
@@ -5,7 +5,7 @@ import { MaxSubscribersData } from "../components/ValidateSubscriber/types";
 import { useAppConfiguration } from "../AppConfiguration";
 import { useMutation, useQuery } from "react-query";
 
-const useDopplerLegacyClient = () => {
+export const useDopplerLegacyClient = () => {
   const appConfiguration = useAppConfiguration();
   const dopplerLegacyClient: DopplerLegacyClient = appConfiguration.useDummies
     ? new DopplerLegacyClientDummy()
@@ -25,13 +25,6 @@ export const useSendMaxSubscribersData = () => {
     async (maxSubscribersData: MaxSubscribersData): Promise<boolean> => {
       return await client.sendMaxSubscribersData(maxSubscribersData);
     }
-  );
-};
-
-export const useSendAcceptButtonAction = () => {
-  const client = useDopplerLegacyClient();
-  return useMutation(
-    async (): Promise<boolean> => await client.sendAcceptButtonAction()
   );
 };
 

--- a/src/components/HeaderMessages.tsx
+++ b/src/components/HeaderMessages.tsx
@@ -3,20 +3,25 @@ import { Modal } from "./Modal";
 import { User, Alert } from "../model";
 import { UpgradePlanForm } from "./UpgradePlanForm";
 import { ValidateSubscribersForm } from "./ValidateSubscriber/ValidateSubscribersForm";
-import { useSendAcceptButtonAction } from "../client/dopplerLegacyClient";
+import { useDopplerLegacyClient } from "../client/dopplerLegacyClient";
 
 interface HeaderMessagesProp {
   alert: Alert;
   user: User;
+  onClose?: () => void;
 }
 
 const upgradePlanPopup = "upgradePlanPopup";
 const validateSubscribersPopup = "validateSubscribersPopup";
 
-export const HeaderMessages = ({ alert, user }: HeaderMessagesProp) => {
+export const HeaderMessages = ({
+  alert,
+  user,
+  onClose,
+}: HeaderMessagesProp) => {
   const [modalIsOpen, setModalIsOpen] = useState(false);
   const [currentAlert, setCurrentAlert] = useState<Alert>(alert);
-  const { mutate: sendAcceptButtonAction } = useSendAcceptButtonAction();
+  const client = useDopplerLegacyClient();
 
   if (!Object.keys(alert).length) {
     return null;
@@ -42,8 +47,12 @@ export const HeaderMessages = ({ alert, user }: HeaderMessagesProp) => {
     if (hasModal) {
       return toggleModal(true);
     }
-    if (alert.button?.action === "closeModal") {
-      return sendAcceptButtonAction();
+    if (currentAlert.button?.action === "closeModal") {
+      return client.sendAcceptButtonAction().then(() => {
+        if (onClose) {
+          onClose();
+        }
+      });
     }
   };
 


### PR DESCRIPTION
Cuando damos clic en el botón **_Entendido_** (de tipo _closeModal_) en un mensaje de alerta ocultamos el mensaje sin recargar la página.

https://user-images.githubusercontent.com/6733401/193661104-85cb74c6-40ee-47eb-9791-853b04e2bb8a.mp4

