### PR TITLE
DE-810 - Menu item on DOM update

### DIFF
--- a/src/hooks/useMeta.test.tsx
+++ b/src/hooks/useMeta.test.tsx
@@ -8,13 +8,12 @@ describe(useMeta.name, () => {
     const metaContent = "content123";
     const metaElement = { content: metaContent } as HTMLMetaElement;
 
-    const querySelectorDouble = (selectors: string) =>
-      selectors == expectedSelector ? metaElement : null;
-
     const { TestComponent, windowDouble } = createTestContext();
-    windowDouble.document = {
-      querySelector: querySelectorDouble,
-    };
+
+    windowDouble.document.querySelector.mockImplementation(
+      (selectors: string) =>
+        selectors == expectedSelector ? metaElement : null
+    );
 
     render(<TestComponent metaName={metaName} />);
 
@@ -24,12 +23,9 @@ describe(useMeta.name, () => {
   it("should return null when meta element is not found", () => {
     const metaName = "metaName123";
 
-    const querySelectorDouble = () => null;
-
     const { TestComponent, windowDouble } = createTestContext();
-    windowDouble.document = {
-      querySelector: querySelectorDouble,
-    };
+
+    windowDouble.document.querySelector.mockImplementation(() => null);
 
     render(<TestComponent metaName={metaName} />);
 
@@ -38,7 +34,11 @@ describe(useMeta.name, () => {
 });
 
 function createTestContext() {
-  const windowDouble: any = {};
+  const windowDouble = {
+    document: {
+      querySelector: jest.fn<HTMLMetaElement | null, [string]>(),
+    },
+  };
 
   const TestComponent = ({ metaName }: { metaName: string }) => {
     const content = useMeta(metaName, windowDouble as any);

--- a/src/hooks/useMeta.test.tsx
+++ b/src/hooks/useMeta.test.tsx
@@ -1,5 +1,9 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import { useMeta } from "./useMeta";
+
+type MutationObserverMock = MutationObserver & {
+  trigger: (mockedMutationsList: MutationRecord[]) => void;
+};
 
 describe(useMeta.name, () => {
   it("should return selected meta content value", () => {
@@ -31,10 +35,224 @@ describe(useMeta.name, () => {
 
     screen.getByText(`[]`);
   });
+
+  it("should update value when meta element is added to DOM in the first mutation", async () => {
+    // Arrange
+    const metaName = "metaName123";
+    const expectedSelector = `meta[name="${metaName}"]`;
+    const metaContentA = "contentA";
+    const metaContentB = "contentB";
+
+    let metaElement = { content: metaContentA } as HTMLMetaElement;
+
+    const { TestComponent, windowDouble, getObserverInstance } =
+      createTestContext();
+
+    windowDouble.document.querySelector.mockImplementation(
+      (selectors: string) =>
+        selectors == expectedSelector ? metaElement : null
+    );
+
+    render(<TestComponent metaName={metaName} />);
+    screen.getByText(`[${metaContentA}]`);
+
+    metaElement = { content: metaContentB } as HTMLMetaElement;
+
+    // Act
+    getObserverInstance(0).trigger([
+      {
+        addedNodes: [
+          {
+            querySelector: () =>
+              expectedSelector
+                ? ({ content: "ANY CONTENT" } as HTMLMetaElement)
+                : null,
+          },
+        ] as any as NodeList,
+        attributeName: null,
+        attributeNamespace: null,
+        nextSibling: null,
+        oldValue: null,
+        previousSibling: null,
+        removedNodes: [] as any as NodeList,
+        target: {} as Node,
+        type: "childList",
+      },
+    ]);
+
+    // Assert
+    await waitFor(() => {
+      screen.getByText(`[${metaContentB}]`);
+    });
+  });
+
+  it("should update value when meta element is added to DOM in the second mutation", async () => {
+    // Arrange
+    const metaName = "metaName123";
+    const expectedSelector = `meta[name="${metaName}"]`;
+    const metaContentA = "contentA";
+    const metaContentB = "contentB";
+
+    let metaElement = { content: metaContentA } as HTMLMetaElement;
+
+    const { TestComponent, windowDouble, getObserverInstance } =
+      createTestContext();
+
+    windowDouble.document.querySelector.mockImplementation(
+      (selectors: string) =>
+        selectors == expectedSelector ? metaElement : null
+    );
+
+    render(<TestComponent metaName={metaName} />);
+    screen.getByText(`[${metaContentA}]`);
+
+    metaElement = { content: metaContentB } as HTMLMetaElement;
+
+    // Act
+    getObserverInstance(0).trigger([
+      {
+        addedNodes: [
+          {},
+          {
+            querySelector: () =>
+              expectedSelector
+                ? ({ content: "ANY CONTENT" } as HTMLMetaElement)
+                : null,
+          },
+        ] as any as NodeList,
+        attributeName: null,
+        attributeNamespace: null,
+        nextSibling: null,
+        oldValue: null,
+        previousSibling: null,
+        removedNodes: [] as any as NodeList,
+        target: {} as Node,
+        type: "childList",
+      },
+    ]);
+
+    // Assert
+    await waitFor(() => {
+      screen.getByText(`[${metaContentB}]`);
+    });
+  });
+
+  it("should update value when meta element is removed from DOM and there is not another one", async () => {
+    // Arrange
+    const metaName = "metaName123";
+    const expectedSelector = `meta[name="${metaName}"]`;
+    const metaContentA = "contentA";
+
+    let metaElement = { content: metaContentA } as HTMLMetaElement;
+
+    const { TestComponent, windowDouble, getObserverInstance } =
+      createTestContext();
+
+    windowDouble.document.querySelector.mockImplementation(
+      (selectors: string) =>
+        selectors == expectedSelector ? metaElement : null
+    );
+
+    render(<TestComponent metaName={metaName} />);
+    screen.getByText(`[${metaContentA}]`);
+
+    windowDouble.document.querySelector.mockImplementation(() => null);
+
+    // Act
+    getObserverInstance(0).trigger([
+      {
+        addedNodes: [] as any as NodeList,
+        attributeName: null,
+        attributeNamespace: null,
+        nextSibling: null,
+        oldValue: null,
+        previousSibling: null,
+        removedNodes: [
+          {
+            querySelector: () =>
+              expectedSelector
+                ? ({ content: "ANY CONTENT" } as HTMLMetaElement)
+                : null,
+          },
+        ] as any as NodeList,
+        target: {} as Node,
+        type: "childList",
+      },
+    ]);
+
+    // Assert
+    await waitFor(() => {
+      screen.getByText(`[]`);
+    });
+  });
+
+  it("should update value when meta element is removed from DOM and there is another one", async () => {
+    // Arrange
+    const metaName = "metaName123";
+    const expectedSelector = `meta[name="${metaName}"]`;
+    const metaContentA = "contentA";
+    const metaContentB = "contentB";
+
+    let metaElement = { content: metaContentA } as HTMLMetaElement;
+
+    const { TestComponent, windowDouble, getObserverInstance } =
+      createTestContext();
+
+    windowDouble.document.querySelector.mockImplementation(
+      (selectors: string) =>
+        selectors == expectedSelector ? metaElement : null
+    );
+
+    render(<TestComponent metaName={metaName} />);
+    screen.getByText(`[${metaContentA}]`);
+
+    metaElement = { content: metaContentB } as HTMLMetaElement;
+
+    // Act
+    getObserverInstance(0).trigger([
+      {
+        addedNodes: [] as any as NodeList,
+        attributeName: null,
+        attributeNamespace: null,
+        nextSibling: null,
+        oldValue: null,
+        previousSibling: null,
+        removedNodes: [
+          {
+            querySelector: () =>
+              expectedSelector
+                ? ({ content: "ANY CONTENT" } as HTMLMetaElement)
+                : null,
+          },
+        ] as any as NodeList,
+        target: {} as Node,
+        type: "childList",
+      },
+    ]);
+
+    // Assert
+    await waitFor(() => {
+      screen.getByText(`[${metaContentB}]`);
+    });
 });
+
+function createMutationObserverCtorMock() {
+  return jest.fn(function MutationObserver(
+    this: MutationObserverMock,
+    callback: MutationCallback
+  ) {
+    this.observe = jest.fn();
+    this.disconnect = jest.fn();
+    this.trigger = (mockedMutationsList: MutationRecord[]) => {
+      callback(mockedMutationsList, this);
+    };
+    return this;
+  });
+}
 
 function createTestContext() {
   const windowDouble = {
+    MutationObserver: createMutationObserverCtorMock(),
     document: {
       querySelector: jest.fn<HTMLMetaElement | null, [string]>(),
     },
@@ -45,5 +263,8 @@ function createTestContext() {
     return <>[{content}]</>;
   };
 
-  return { TestComponent, windowDouble };
+  const getObserverInstance = (index: number = 0) =>
+    windowDouble.MutationObserver.mock.instances[index];
+
+  return { TestComponent, windowDouble, getObserverInstance };
 }

--- a/src/hooks/useMeta.test.tsx
+++ b/src/hooks/useMeta.test.tsx
@@ -137,6 +137,56 @@ describe(useMeta.name, () => {
     });
   });
 
+  it("should update value when meta element is the only added element to DOM", async () => {
+    // Arrange
+    const metaName = "metaName123";
+    const expectedSelector = `meta[name="${metaName}"]`;
+    const metaContentA = "contentA";
+    const metaContentB = "contentB";
+
+    let metaElement = { content: metaContentA } as HTMLMetaElement;
+
+    const { TestComponent, windowDouble, getObserverInstance } =
+      createTestContext();
+
+    windowDouble.document.querySelector.mockImplementation(
+      (selectors: string) =>
+        selectors == expectedSelector ? metaElement : null
+    );
+
+    render(<TestComponent metaName={metaName} />);
+    screen.getByText(`[${metaContentA}]`);
+
+    metaElement = { content: metaContentB } as HTMLMetaElement;
+
+    // Act
+    getObserverInstance(0).trigger([
+      {
+        addedNodes: [
+          {
+            nodeName: "META",
+            name: metaName,
+            content: metaContentB,
+            querySelector: () => null,
+          },
+        ] as any as NodeList,
+        attributeName: null,
+        attributeNamespace: null,
+        nextSibling: null,
+        oldValue: null,
+        previousSibling: null,
+        removedNodes: [] as any as NodeList,
+        target: {} as Node,
+        type: "childList",
+      },
+    ]);
+
+    // Assert
+    await waitFor(() => {
+      screen.getByText(`[${metaContentB}]`);
+    });
+  });
+
   it("should update value when meta element is removed from DOM and there is not another one", async () => {
     // Arrange
     const metaName = "metaName123";

--- a/src/hooks/useMeta.tsx
+++ b/src/hooks/useMeta.tsx
@@ -29,7 +29,12 @@ function isAnyMutationRelated(mutations: MutationRecord[], name: string) {
       for (const nodeList of [mutation.addedNodes, mutation.removedNodes]) {
         for (let index = 0; index < nodeList.length; index++) {
           const node = nodeList[index];
-          // TODO: confirm if it works when meta is the only added element
+          if (
+            node.nodeName === "META" &&
+            (node as HTMLMetaElement).name === name
+          ) {
+            return true;
+          }
           if ("querySelector" in node && readMeta(node as ParentNode, name)) {
             return true;
           }

--- a/src/hooks/useMeta.tsx
+++ b/src/hooks/useMeta.tsx
@@ -1,6 +1,9 @@
 import { useMutationObserver } from "./useMutationObserver";
 
-export function useMeta(name: string, global: Window = window) {
+export function useMeta(
+  name: string,
+  global: Window & typeof globalThis = window
+) {
   const content = useMutationObserver({
     targetNode: global.document.body,
     config: {
@@ -14,6 +17,7 @@ export function useMeta(name: string, global: Window = window) {
         setValue(newContent);
       }
     },
+    global,
   });
 
   return content;

--- a/src/hooks/useMeta.tsx
+++ b/src/hooks/useMeta.tsx
@@ -1,19 +1,17 @@
-import { useState } from "react";
 import { useMutationObserver } from "./useMutationObserver";
 
 export function useMeta(name: string, global: Window = window) {
-  const [content, setContent] = useState(() => readMeta(global.document, name));
-
-  useMutationObserver({
+  const content = useMutationObserver({
     targetNode: global.document.body,
     config: {
       subtree: true,
       childList: true,
     },
-    callback: (mutations) => {
+    initialValue: () => readMeta(global.document, name),
+    onMutation: (mutations, setValue) => {
       if (isAnyMutationRelated(mutations, name)) {
         const newContent = readMeta(global.document, name);
-        setContent(newContent);
+        setValue(newContent);
       }
     },
   });

--- a/src/hooks/useMeta.tsx
+++ b/src/hooks/useMeta.tsx
@@ -1,12 +1,43 @@
 import { useState } from "react";
+import { useMutationObserver } from "./useMutationObserver";
 
 export function useMeta(name: string, global: Window = window) {
-  // TODO: listening DOM changes and update the value
-  // https://makingsense.atlassian.net/browse/DE-810
-  const [content] = useState(
-    () =>
-      global.document.querySelector<HTMLMetaElement>(`meta[name="${name}"]`)
-        ?.content || null
-  );
+  const [content, setContent] = useState(() => readMeta(global.document, name));
+
+  useMutationObserver({
+    targetNode: global.document.body,
+    config: {
+      subtree: true,
+      childList: true,
+    },
+    callback: (mutations) => {
+      if (isAnyMutationRelated(mutations, name)) {
+        const newContent = readMeta(global.document, name);
+        setContent(newContent);
+      }
+    },
+  });
+
   return content;
+}
+
+function isAnyMutationRelated(mutations: MutationRecord[], name: string) {
+  for (const mutation of mutations) {
+    for (const nodeList of [mutation.addedNodes, mutation.removedNodes]) {
+      for (let index = 0; index < nodeList.length; index++) {
+        const node = nodeList[index];
+        // TODO: confirm if it works when meta is the only added element
+        if ("querySelector" in node && readMeta(node as ParentNode, name)) {
+          return true;
+        }
+      }
+    }
+  }
+  return false;
+}
+
+function readMeta(node: ParentNode, name: string): string | null {
+  return (
+    node.querySelector<HTMLMetaElement>(`meta[name="${name}"]`)?.content || null
+  );
 }

--- a/src/hooks/useMeta.tsx
+++ b/src/hooks/useMeta.tsx
@@ -25,12 +25,14 @@ export function useMeta(
 
 function isAnyMutationRelated(mutations: MutationRecord[], name: string) {
   for (const mutation of mutations) {
-    for (const nodeList of [mutation.addedNodes, mutation.removedNodes]) {
-      for (let index = 0; index < nodeList.length; index++) {
-        const node = nodeList[index];
-        // TODO: confirm if it works when meta is the only added element
-        if ("querySelector" in node && readMeta(node as ParentNode, name)) {
-          return true;
+    if (mutation.type === "childList") {
+      for (const nodeList of [mutation.addedNodes, mutation.removedNodes]) {
+        for (let index = 0; index < nodeList.length; index++) {
+          const node = nodeList[index];
+          // TODO: confirm if it works when meta is the only added element
+          if ("querySelector" in node && readMeta(node as ParentNode, name)) {
+            return true;
+          }
         }
       }
     }

--- a/src/hooks/useMutationObserver.ts
+++ b/src/hooks/useMutationObserver.ts
@@ -5,6 +5,7 @@ export function useMutationObserver<T>({
   config,
   initialValue,
   onMutation,
+  global = window,
 }: {
   targetNode: HTMLElement;
   config: MutationObserverInit;
@@ -13,16 +14,15 @@ export function useMutationObserver<T>({
     mutations: MutationRecord[],
     setValue: (newValue: T) => void
   ) => void;
+  global?: Window & typeof globalThis;
 }): T {
   const [value, setValue] = useState(initialValue);
-
   const observer = useMemo(
     () =>
-      // TODO: allow to inject this factory to make it testable
-      new MutationObserver((mutationList) =>
+      new global.MutationObserver((mutationList) =>
         onMutation(mutationList, setValue)
       ),
-    [onMutation, setValue]
+    [onMutation, setValue, global.MutationObserver]
   );
 
   useEffect(() => {

--- a/src/hooks/useMutationObserver.ts
+++ b/src/hooks/useMutationObserver.ts
@@ -1,0 +1,37 @@
+import { useEffect, useMemo, useState } from "react";
+
+const identity = (x: any) => x;
+
+export function useMutationObserver<T = MutationRecord[]>({
+  targetNode,
+  config,
+  callback = identity,
+}: {
+  targetNode: HTMLElement;
+  config: MutationObserverInit;
+  callback?: (mutations: MutationRecord[], observer: MutationObserver) => T;
+}): T | undefined {
+  // TODO: allow to set initial value
+  const [value, setValue] = useState<T | undefined>(undefined);
+
+  const observer = useMemo(
+    () =>
+      // TODO: allow to inject this factory to make it testable
+      new MutationObserver((mutationList, observer) => {
+        const result = callback(mutationList, observer);
+        setValue(result);
+      }),
+    [callback]
+  );
+  
+  useEffect(() => {
+    if (targetNode) {
+      observer.observe(targetNode, config);
+      return () => {
+        observer.disconnect();
+      };
+    }
+  }, [targetNode, config, observer]);
+
+  return value;
+}


### PR DESCRIPTION
It listens to DOM updates in order to update the active menu item.

- [x] Add tests
- [x] Add meta tags to WebApp
   - See https://github.com/FromDoppler/doppler-webapp/pull/2140
- [x] Document usage of `doppler-menu-mfe:default-active-item` and `doppler-menu-mfe:force-active-item` meta tags (and all public API of Menu MFE)
   - See related documentation in #195: https://github.com/FromDoppler/doppler-menu-mfe/pull/195/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R55
- [x] `// TODO: confirm if it works when meta is the only added element`
   - Fixed! thanks @leoslopez !
- [x] Decide if the refactoring [refactor: modify useMutationObserver to always return a valid state](https://github.com/FromDoppler/doppler-menu-mfe/pull/191/commits/67d5931b6b53f3313bf3ceee7a53a85f2ea3b18e) is good or bad
   - We will keep the refactoring

