### PR TITLE
Add missing act wrappers

### DIFF
--- a/src/hooks/useMeta.test.tsx
+++ b/src/hooks/useMeta.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen, waitFor } from "@testing-library/react";
+import { act } from "react-dom/test-utils";
 import { useMeta } from "./useMeta";
 
 type MutationObserverMock = MutationObserver & {
@@ -59,26 +60,28 @@ describe(useMeta.name, () => {
     metaElement = { content: metaContentB } as HTMLMetaElement;
 
     // Act
-    getObserverInstance(0).trigger([
-      {
-        addedNodes: [
-          {
-            querySelector: () =>
-              expectedSelector
-                ? ({ content: "ANY CONTENT" } as HTMLMetaElement)
-                : null,
-          },
-        ] as any as NodeList,
-        attributeName: null,
-        attributeNamespace: null,
-        nextSibling: null,
-        oldValue: null,
-        previousSibling: null,
-        removedNodes: [] as any as NodeList,
-        target: {} as Node,
-        type: "childList",
-      },
-    ]);
+    act(() => {
+      getObserverInstance(0).trigger([
+        {
+          addedNodes: [
+            {
+              querySelector: () =>
+                expectedSelector
+                  ? ({ content: "ANY CONTENT" } as HTMLMetaElement)
+                  : null,
+            },
+          ] as any as NodeList,
+          attributeName: null,
+          attributeNamespace: null,
+          nextSibling: null,
+          oldValue: null,
+          previousSibling: null,
+          removedNodes: [] as any as NodeList,
+          target: {} as Node,
+          type: "childList",
+        },
+      ]);
+    });
 
     // Assert
     await waitFor(() => {
@@ -109,27 +112,29 @@ describe(useMeta.name, () => {
     metaElement = { content: metaContentB } as HTMLMetaElement;
 
     // Act
-    getObserverInstance(0).trigger([
-      {
-        addedNodes: [
-          {},
-          {
-            querySelector: () =>
-              expectedSelector
-                ? ({ content: "ANY CONTENT" } as HTMLMetaElement)
-                : null,
-          },
-        ] as any as NodeList,
-        attributeName: null,
-        attributeNamespace: null,
-        nextSibling: null,
-        oldValue: null,
-        previousSibling: null,
-        removedNodes: [] as any as NodeList,
-        target: {} as Node,
-        type: "childList",
-      },
-    ]);
+    act(() => {
+      getObserverInstance(0).trigger([
+        {
+          addedNodes: [
+            {},
+            {
+              querySelector: () =>
+                expectedSelector
+                  ? ({ content: "ANY CONTENT" } as HTMLMetaElement)
+                  : null,
+            },
+          ] as any as NodeList,
+          attributeName: null,
+          attributeNamespace: null,
+          nextSibling: null,
+          oldValue: null,
+          previousSibling: null,
+          removedNodes: [] as any as NodeList,
+          target: {} as Node,
+          type: "childList",
+        },
+      ]);
+    });
 
     // Assert
     await waitFor(() => {
@@ -160,26 +165,28 @@ describe(useMeta.name, () => {
     metaElement = { content: metaContentB } as HTMLMetaElement;
 
     // Act
-    getObserverInstance(0).trigger([
-      {
-        addedNodes: [
-          {
-            nodeName: "META",
-            name: metaName,
-            content: metaContentB,
-            querySelector: () => null,
-          },
-        ] as any as NodeList,
-        attributeName: null,
-        attributeNamespace: null,
-        nextSibling: null,
-        oldValue: null,
-        previousSibling: null,
-        removedNodes: [] as any as NodeList,
-        target: {} as Node,
-        type: "childList",
-      },
-    ]);
+    act(() => {
+      getObserverInstance(0).trigger([
+        {
+          addedNodes: [
+            {
+              nodeName: "META",
+              name: metaName,
+              content: metaContentB,
+              querySelector: () => null,
+            },
+          ] as any as NodeList,
+          attributeName: null,
+          attributeNamespace: null,
+          nextSibling: null,
+          oldValue: null,
+          previousSibling: null,
+          removedNodes: [] as any as NodeList,
+          target: {} as Node,
+          type: "childList",
+        },
+      ]);
+    });
 
     // Assert
     await waitFor(() => {
@@ -209,26 +216,28 @@ describe(useMeta.name, () => {
     windowDouble.document.querySelector.mockImplementation(() => null);
 
     // Act
-    getObserverInstance(0).trigger([
-      {
-        addedNodes: [] as any as NodeList,
-        attributeName: null,
-        attributeNamespace: null,
-        nextSibling: null,
-        oldValue: null,
-        previousSibling: null,
-        removedNodes: [
-          {
-            querySelector: () =>
-              expectedSelector
-                ? ({ content: "ANY CONTENT" } as HTMLMetaElement)
-                : null,
-          },
-        ] as any as NodeList,
-        target: {} as Node,
-        type: "childList",
-      },
-    ]);
+    act(() => {
+      getObserverInstance(0).trigger([
+        {
+          addedNodes: [] as any as NodeList,
+          attributeName: null,
+          attributeNamespace: null,
+          nextSibling: null,
+          oldValue: null,
+          previousSibling: null,
+          removedNodes: [
+            {
+              querySelector: () =>
+                expectedSelector
+                  ? ({ content: "ANY CONTENT" } as HTMLMetaElement)
+                  : null,
+            },
+          ] as any as NodeList,
+          target: {} as Node,
+          type: "childList",
+        },
+      ]);
+    });
 
     // Assert
     await waitFor(() => {
@@ -259,26 +268,28 @@ describe(useMeta.name, () => {
     metaElement = { content: metaContentB } as HTMLMetaElement;
 
     // Act
-    getObserverInstance(0).trigger([
-      {
-        addedNodes: [] as any as NodeList,
-        attributeName: null,
-        attributeNamespace: null,
-        nextSibling: null,
-        oldValue: null,
-        previousSibling: null,
-        removedNodes: [
-          {
-            querySelector: () =>
-              expectedSelector
-                ? ({ content: "ANY CONTENT" } as HTMLMetaElement)
-                : null,
-          },
-        ] as any as NodeList,
-        target: {} as Node,
-        type: "childList",
-      },
-    ]);
+    act(() => {
+      getObserverInstance(0).trigger([
+        {
+          addedNodes: [] as any as NodeList,
+          attributeName: null,
+          attributeNamespace: null,
+          nextSibling: null,
+          oldValue: null,
+          previousSibling: null,
+          removedNodes: [
+            {
+              querySelector: () =>
+                expectedSelector
+                  ? ({ content: "ANY CONTENT" } as HTMLMetaElement)
+                  : null,
+            },
+          ] as any as NodeList,
+          target: {} as Node,
+          type: "childList",
+        },
+      ]);
+    });
 
     // Assert
     await waitFor(() => {
@@ -309,27 +320,29 @@ describe(useMeta.name, () => {
     metaElement = { content: metaContentB } as HTMLMetaElement;
 
     // Act
-    getObserverInstance(0).trigger([
-      {
-        addedNodes: [
-          {},
-          {
-            querySelector: () =>
-              expectedSelector
-                ? ({ content: "ANY CONTENT" } as HTMLMetaElement)
-                : null,
-          },
-        ] as any as NodeList,
-        attributeName: null,
-        attributeNamespace: null,
-        nextSibling: null,
-        oldValue: null,
-        previousSibling: null,
-        removedNodes: [] as any as NodeList,
-        target: {} as Node,
-        type: "attributes",
-      },
-    ]);
+    act(() => {
+      getObserverInstance(0).trigger([
+        {
+          addedNodes: [
+            {},
+            {
+              querySelector: () =>
+                expectedSelector
+                  ? ({ content: "ANY CONTENT" } as HTMLMetaElement)
+                  : null,
+            },
+          ] as any as NodeList,
+          attributeName: null,
+          attributeNamespace: null,
+          nextSibling: null,
+          oldValue: null,
+          previousSibling: null,
+          removedNodes: [] as any as NodeList,
+          target: {} as Node,
+          type: "attributes",
+        },
+      ]);
+    });
 
     // Assert
     await timeout(1);


### PR DESCRIPTION
It removes some of the warnings in the tests, but not all:

After:

<img width="1205" alt="image" src="https://user-images.githubusercontent.com/1157864/196523798-6bcdbc55-6a1d-4355-8fbf-752b31dbddb3.png">

Before: 

<img width="1214" alt="image" src="https://user-images.githubusercontent.com/1157864/196524166-2ec7d817-ae1b-4de4-82a5-87d60ce4f762.png">
