### PR TITLE
fix: remove wrong content-type header

### DIFF
--- a/src/client/DopplerLegacyClientImpl.ts
+++ b/src/client/DopplerLegacyClientImpl.ts
@@ -72,13 +72,14 @@ export class DopplerLegacyClientImpl implements DopplerLegacyClient {
   public async sendMaxSubscribersData(
     maxSubscribersData: MaxSubscribersData
   ): Promise<boolean> {
-    const response = await this.axios.post(
-      "/sendmaxsubscribersemail/sendemailpopup",
-      mapMaxSubscribersDataToJson(maxSubscribersData),
-      {
-        headers: { "Content-Type": "application/x-www-form-urlencoded" },
-      }
-    );
+    const response = await this.axios({
+      method: "post",
+      url: "/sendmaxsubscribersemail/sendemailpopup",
+      // Hack: it is to avoid Axios automatic serialization as x-www-form-urlencoded
+      data: JSON.stringify(mapMaxSubscribersDataToJson(maxSubscribersData)),
+      // Hack: It is to avoid CORS Preflight
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    });
     return response.data;
   }
 


### PR DESCRIPTION
The backend is clearly expecting a JSON ([see the code](https://github.com/MakingSense/Doppler/blob/55e7819c1c590e81f2fc16713ee0483b0bca8c14/Doppler.Presentation.MVC/Controllers/SendMaxSubscribersEmailController.cs#L106-L113) it is ugly but expects a JSON).

It seems that the previous Axios version did not make honor to this header and the new one does.

---

The header was there to avoid CORS Preflight, I restore the previous behavior to avoid doing changes in the Doppler backend.