### PR TITLE
fix: add missing type to the buttons

### DIFF
--- a/src/components/HeaderMessages.tsx
+++ b/src/components/HeaderMessages.tsx
@@ -121,7 +121,11 @@ const ActionComponent = ({
   }
 
   return (
-    <button className="button button--light button--tiny" onClick={onClick}>
+    <button
+      type="button"
+      className="button button--light button--tiny"
+      onClick={onClick}
+    >
       {children}
     </button>
   );

--- a/src/components/UserPlan.tsx
+++ b/src/components/UserPlan.tsx
@@ -176,6 +176,7 @@ const UpdatePlanButton = (props: UpdatePlanButtonProp) => {
       <div className="dp-request-sent">
         <Tooltip>
           <button
+            type="button"
             onClick={props.click}
             className="user-plan close-user--menu dp-tooltip-left"
           >
@@ -190,7 +191,7 @@ const UpdatePlanButton = (props: UpdatePlanButtonProp) => {
     );
   }
   return (
-    <button onClick={props.click} className="user-plan">
+    <button type="button" onClick={props.click} className="user-plan">
       {props.text}
     </button>
   );


### PR DESCRIPTION
Hi team!

It seems that Reports has a Form in the complete page body, and we missed the _type_ in some _buttons_, so they worked as _submit_.

![image](https://user-images.githubusercontent.com/1157864/212916002-11b84c48-bb86-4253-93fa-d774392cda40.png)

![image](https://user-images.githubusercontent.com/1157864/212916246-b2eef4a2-108d-4b40-9f52-87257e965cd7.png)

It should fix the issue, testing...