### PR TITLE
[DOI-1224] Fix for conversations secction not display doppler menu

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -41,7 +41,10 @@ function App({
     defaultDashboardUrl;
 
   return (
-    <>
+    //Use div instead of react fragment here. // See https://stackoverflow.com/questions/54880669/
+    // react-domexception-failed-to-execute-removechild-on-node-the-node-to-be-re#:~:text=Problem%
+    // 20explanation%3A
+    <div>
       {
         // TODO: confirm if it is rendered in the right way
         alert && !hideHeaderMessage ? (
@@ -56,7 +59,7 @@ function App({
         sticky={!!alert && !hideHeaderMessage}
         dashboardUrl={dashboardUrl}
       />
-    </>
+    </div>
   );
 }
 


### PR DESCRIPTION
It seems there is an issue on the first render when accessing the conversations secction. It doesnt display the menu and throws an error in the console (Uncaught DOMException: Failed to execute 'removeChild' on 'Node': The node to be removed is not a child of this node.)
It seems to be related to the header notification because it doesn't happen when there is no notification to display.

It might be related to this: https://stackoverflow.com/questions/54880669/react-domexception-failed-to-execute-removechild-on-node-the-node-to-be-re#:~:text=Problem%20explanation%3A

If it doesn't work i will revert this.