### PR TITLE
[DOI-1533] Move user selection modal to app component

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -27,6 +27,7 @@ test("renders Doppler Menu Micro-Frontend", () => {
     getCurrentSessionState: () => appSessionState,
     onSessionUpdate: () => {},
     start: () => {},
+    restart: () => {},
   };
   const queryClient = new QueryClient();
 

--- a/src/components/UserMenu.tsx
+++ b/src/components/UserMenu.tsx
@@ -49,7 +49,7 @@ export const UserMenu = ({ user }: UserMenuProps) => {
             <div className="dp-info-user">
               <p>
                 <span className="name">{fullname}</span>
-                <span className="email">{userAccount.email}</span>
+                <span className="email">{email}</span>
                 <span className="dp-account-status">
                   <span>
                     <FormattedMessage

--- a/src/components/UserMenu.tsx
+++ b/src/components/UserMenu.tsx
@@ -4,9 +4,8 @@ import { User } from "../model";
 import { Avatar } from "./Avatar";
 import { UserPlan } from "./UserPlan";
 import { ClientManagerUserPlan } from "./ClientManagerUserPlan";
-import { Modal } from "./Modal";
 import { FormattedMessage } from "react-intl";
-import { UserSelection } from "./UserSelection";
+import { useUserSelectionContext } from "../App";
 
 interface UserMenuProps {
   user: User;
@@ -17,7 +16,6 @@ export const UserMenu = ({ user }: UserMenuProps) => {
   const { color: backgroundColor, text: avatarText } = avatar;
 
   const [openUserMenu, setOpenUserMenu] = useState(false);
-  const [openUserSelection, setOpenUserSelection] = useState(false);
   const showRelatedUsersMenu =
     userAccount &&
     ((relatedUsers && relatedUsers.length > 1) ||
@@ -30,9 +28,7 @@ export const UserMenu = ({ user }: UserMenuProps) => {
     setOpenUserMenu((prev) => !prev);
   };
 
-  const handleToggleModal = () => {
-    setOpenUserSelection((prev) => !prev);
-  };
+  const { setOpenUserSelection } = useUserSelectionContext();
 
   return (
     <div ref={userMenuRef}>
@@ -65,7 +61,7 @@ export const UserMenu = ({ user }: UserMenuProps) => {
               <button
                 type="button"
                 className="dp-button button-small primary-green dp-w-100"
-                onClick={handleToggleModal}
+                onClick={() => setOpenUserSelection(true)}
               >
                 <FormattedMessage id="header.change_account_button" />
               </button>
@@ -102,20 +98,6 @@ export const UserMenu = ({ user }: UserMenuProps) => {
             </li>
           ))}
         </ul>
-        {openUserSelection && relatedUsers ? (
-          <Modal
-            isOpen={openUserSelection}
-            handleClose={() => setOpenUserSelection(false)}
-            modalId="modal-all-accounts"
-          >
-            <UserSelection
-              data={relatedUsers}
-              currentUser={email}
-            ></UserSelection>
-          </Modal>
-        ) : (
-          <></>
-        )}
       </div>
     </div>
   );

--- a/src/components/UserSelection.tsx
+++ b/src/components/UserSelection.tsx
@@ -3,7 +3,7 @@ import { RelatedUsersData } from "../model";
 import { useState } from "react";
 import { useChangeUserSession } from "../client/dopplerLegacyClient";
 import { SessionMfeAppSessionStateClient } from "../session/SessionMfeAppSessionStateClient";
-import { AppConfiguration } from "../AppConfiguration";
+import { useAppConfiguration } from "../AppConfiguration";
 import { createDummyAppSessionStateClient } from "../session/dummyAppSessionStateClient";
 import { Avatar } from "./Avatar";
 
@@ -12,10 +12,9 @@ interface UserSelectionProps {
   currentUser: string;
 }
 
-function createAppSessionStateClient() {
-  const configuration: AppConfiguration =
-    (window as any)["doppler-menu-mfe-configuration"] ?? {};
-  return configuration.useDummies
+function useCreateAppSessionStateClient() {
+  const { useDummies } = useAppConfiguration();
+  return useDummies
     ? createDummyAppSessionStateClient()
     : new SessionMfeAppSessionStateClient({ window });
 }
@@ -27,7 +26,7 @@ export const UserSelection = ({ data, currentUser }: UserSelectionProps) => {
     }),
   );
 
-  const appSessionStateClient = createAppSessionStateClient();
+  const appSessionStateClient = useCreateAppSessionStateClient();
 
   const {
     mutate: sendChangeUserSessionMutate,


### PR DESCRIPTION
To avoid an overlapping with the notification banner we need to have the modal at the same level as the `HeaderMessages` component, that being the `App` component.